### PR TITLE
using only service.id when updating a plugin

### DIFF
--- a/solver/kong/plugin.go
+++ b/solver/kong/plugin.go
@@ -69,6 +69,9 @@ func (s *PluginCRUD) Update(arg ...crud.Arg) (crud.Arg, error) {
 	event := eventFromArg(arg[0])
 	plugin := pluginFromStuct(event)
 
+	if plugin.Service != nil {
+		plugin.Service = &kong.Service{ID: plugin.Service.ID}
+	}
 	updatedPlugin, err := s.client.Plugins.Create(nil, &plugin.Plugin)
 	if err != nil {
 		return nil, err

--- a/solver/kong/plugin.go
+++ b/solver/kong/plugin.go
@@ -72,6 +72,12 @@ func (s *PluginCRUD) Update(arg ...crud.Arg) (crud.Arg, error) {
 	if plugin.Service != nil {
 		plugin.Service = &kong.Service{ID: plugin.Service.ID}
 	}
+	if plugin.Route != nil {
+		plugin.Route = &kong.Route{ID: plugin.Route.ID}
+	}
+	if plugin.Consumer != nil {
+		plugin.Consumer = &kong.Consumer{ID: plugin.Consumer.ID}
+	}
 	updatedPlugin, err := s.client.Plugins.Create(nil, &plugin.Plugin)
 	if err != nil {
 		return nil, err

--- a/solver/kong/route.go
+++ b/solver/kong/route.go
@@ -69,6 +69,9 @@ func (s *RouteCRUD) Update(arg ...crud.Arg) (crud.Arg, error) {
 	event := eventFromArg(arg[0])
 	route := routeFromStuct(event)
 
+	if route.Service != nil {
+		route.Service = &kong.Service{ID: route.Service.ID}
+	}
 	updatedRoute, err := s.client.Routes.Create(nil, &route.Route)
 	if err != nil {
 		return nil, err

--- a/solver/kong/route.go
+++ b/solver/kong/route.go
@@ -69,9 +69,6 @@ func (s *RouteCRUD) Update(arg ...crud.Arg) (crud.Arg, error) {
 	event := eventFromArg(arg[0])
 	route := routeFromStuct(event)
 
-	if route.Service != nil {
-		route.Service = &kong.Service{ID: route.Service.ID}
-	}
 	updatedRoute, err := s.client.Routes.Create(nil, &route.Route)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
@hbagdi Updating a plugin works when a plugin is set for a `route`, but when set for a `service` it fails, basically because of the following:

**Bad Request**: `PUT /plugins/<id> {..., service: {id: <service-id>, <everything else from service>}} // full service struct included`

```json
{
  "message": "schema violation (protocols: must match the protocols of at least one route pointing to this Plugin's service)",
  "name": "schema violation",
  "fields": {
    "protocols": "must match the protocols of at least one route pointing to this Plugin's service"
  },
  "code": 2
}
```

**This works**: `PUT /plugins/<id> {..., service: {id: <service-id>}} // only service.id included`

Creating a new `service` with only the ID and assigning it to the `plugin` before calling `s.client.Plugins.Create(nil, &plugin.Plugin)` solves the issue.

Again, thank you!!