### PR TITLE
fix(solver) set foreign ID only for plugins PUT requests

### DIFF
--- a/solver/kong/plugin.go
+++ b/solver/kong/plugin.go
@@ -40,6 +40,16 @@ func pluginFromStuct(arg diff.Event) *state.Plugin {
 func (s *PluginCRUD) Create(arg ...crud.Arg) (crud.Arg, error) {
 	event := eventFromArg(arg[0])
 	plugin := pluginFromStuct(event)
+
+	if plugin.Service != nil {
+		plugin.Service = &kong.Service{ID: plugin.Service.ID}
+	}
+	if plugin.Route != nil {
+		plugin.Route = &kong.Route{ID: plugin.Route.ID}
+	}
+	if plugin.Consumer != nil {
+		plugin.Consumer = &kong.Consumer{ID: plugin.Consumer.ID}
+	}
 	createdPlugin, err := s.client.Plugins.Create(nil, &plugin.Plugin)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Kong 1.1 introduces a change where specifying the name and id of the
service on a POST request results in an incorrect error from Kong.

While, this is a bug in Kong, Kong doesn't promise any compat for cases
when Admin API reqeusts contains entire nested foreign objects.