### PR TITLE
feat: add support for tag based config mgmt

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -29,11 +29,12 @@ that will be created or updated or deleted.
 		if err != nil {
 			return err
 		}
-		currentState, err := dump.GetState(client, dumpConfig)
+		targetState, selectTags, err := file.GetStateFromFile(diffCmdKongStateFile)
 		if err != nil {
 			return err
 		}
-		targetState, err := file.GetStateFromFile(diffCmdKongStateFile)
+		dumpConfig.SelectorTags = selectTags
+		currentState, err := dump.GetState(client, dumpConfig)
 		if err != nil {
 			return err
 		}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -30,7 +30,8 @@ configure Kong.`,
 		if err != nil {
 			return err
 		}
-		if err := file.KongStateToFile(ks, dumpCmdKongStateFile); err != nil {
+		if err := file.KongStateToFile(ks, dumpConfig.SelectorTags,
+			dumpCmdKongStateFile); err != nil {
 			return err
 		}
 		return nil
@@ -45,4 +46,9 @@ func init() {
 	dumpCmd.Flags().BoolVar(&dumpConfig.SkipConsumers, "skip-consumers",
 		false, "skip exporting consumers and any plugins associated "+
 			"with consumers")
+	dumpCmd.Flags().StringSliceVar(&dumpConfig.SelectorTags,
+		"select-tag", []string{},
+		"only entities matching tags specified via this flag are exported.\n"+
+			"Multiple tags are ANDed together.")
+
 }

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -78,4 +78,8 @@ func init() {
 	resetCmd.Flags().BoolVar(&dumpConfig.SkipConsumers, "skip-consumers",
 		false, "do not reset consumers or "+
 			"any plugins associated with consumers")
+	resetCmd.Flags().StringSliceVar(&dumpConfig.SelectorTags,
+		"select-tag", []string{},
+		"only entities matching tags specified via this flag are deleted.\n"+
+			"Multiple tags are ANDed together.")
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -26,11 +26,12 @@ to get Kong's state in sync with the input state.`,
 		if err != nil {
 			return err
 		}
-		currentState, err := dump.GetState(client, dumpConfig)
+		targetState, selectTags, err := file.GetStateFromFile(syncCmdKongStateFile)
 		if err != nil {
 			return err
 		}
-		targetState, err := file.GetStateFromFile(syncCmdKongStateFile)
+		dumpConfig.SelectorTags = selectTags
+		currentState, err := dump.GetState(client, dumpConfig)
 		if err != nil {
 			return err
 		}

--- a/counter/counter.go
+++ b/counter/counter.go
@@ -15,3 +15,8 @@ func (c *Counter) Inc() uint64 {
 func (c *Counter) Value() uint64 {
 	return atomic.LoadUint64((*uint64)(c))
 }
+
+// Reset resets the counter to 0.
+func (c *Counter) Reset() {
+	atomic.StoreUint64((*uint64)(c), 0)
+}

--- a/counter/counter_test.go
+++ b/counter/counter_test.go
@@ -12,4 +12,6 @@ func TestCounter(t *testing.T) {
 	assert.Equal(uint64(0), c.Value())
 	assert.Equal(uint64(1), c.Inc())
 	assert.Equal(uint64(1), c.Value())
+	c.Reset()
+	assert.Equal(uint64(0), c.Value())
 }

--- a/file/reader_test.go
+++ b/file/reader_test.go
@@ -65,7 +65,7 @@ func TestReadKongStateFromStdinFailsToParseText(t *testing.T) {
 
 	os.Stdin = tmpfile
 
-	ks, err := GetStateFromFile(filename)
+	ks, _, err := GetStateFromFile(filename)
 	assert.NotNil(err)
 	assert.Nil(ks)
 }
@@ -97,7 +97,7 @@ func TestReadKongStateFromStdin(t *testing.T) {
 
 	os.Stdin = tmpfile
 
-	ks, err := GetStateFromFile(filename)
+	ks, _, err := GetStateFromFile(filename)
 	assert.NotNil(ks)
 	assert.Nil(err)
 

--- a/file/types.go
+++ b/file/types.go
@@ -35,7 +35,13 @@ type consumer struct {
 	Plugins       []*plugin `yaml:",omitempty"`
 }
 
+// Info contains meta-data of the file.
+type Info struct {
+	SelectorTags []string `yaml:"select_tags,omitempty"`
+}
+
 type fileStructure struct {
+	Info         Info          `yaml:"_info,omitempty"`
 	Services     []service     `yaml:",omitempty"`
 	Upstreams    []upstream    `yaml:",omitempty"`
 	Certificates []certificate `yaml:",omitempty"`

--- a/file/types.go
+++ b/file/types.go
@@ -2,37 +2,44 @@ package file
 
 import "github.com/hbagdi/go-kong/kong"
 
-type service struct {
+// Service represents a Kong Service and it's associated routes and plugins.
+type Service struct {
 	kong.Service `yaml:",inline,omitempty"`
-	Routes       []*route  `yaml:",omitempty"`
-	Plugins      []*plugin `yaml:",omitempty"`
+	Routes       []*Route  `yaml:",omitempty"`
+	Plugins      []*Plugin `yaml:",omitempty"`
 }
 
-type route struct {
+// Route represents a Kong Route and it's associated plugins.
+type Route struct {
 	kong.Route `yaml:",inline,omitempty"`
-	Plugins    []*plugin `yaml:",omitempty"`
+	Plugins    []*Plugin `yaml:",omitempty"`
 }
 
-type upstream struct {
+// Upstream represents a Kong Upstream and it's associated targets.
+type Upstream struct {
 	kong.Upstream `yaml:",inline,omitempty"`
-	Targets       []*target `yaml:",omitempty"`
+	Targets       []*Target `yaml:",omitempty"`
 }
 
-type target struct {
+// Target represents a Kong Target.
+type Target struct {
 	kong.Target `yaml:",inline,omitempty"`
 }
 
-type certificate struct {
+// Certificate represents a Kong Certificate.
+type Certificate struct {
 	kong.Certificate `yaml:",inline,omitempty"`
 }
 
-type plugin struct {
+// Plugin represents a plugin in Kong.
+type Plugin struct {
 	kong.Plugin `yaml:",inline,omitempty"`
 }
 
-type consumer struct {
+// Consumer represents a consumer in Kong.
+type Consumer struct {
 	kong.Consumer `yaml:",inline,omitempty"`
-	Plugins       []*plugin `yaml:",omitempty"`
+	Plugins       []*Plugin `yaml:",omitempty"`
 }
 
 // Info contains meta-data of the file.
@@ -40,11 +47,12 @@ type Info struct {
 	SelectorTags []string `yaml:"select_tags,omitempty"`
 }
 
-type fileStructure struct {
+// Content represents a serialized Kong state.
+type Content struct {
 	Info         Info          `yaml:"_info,omitempty"`
-	Services     []service     `yaml:",omitempty"`
-	Upstreams    []upstream    `yaml:",omitempty"`
-	Certificates []certificate `yaml:",omitempty"`
-	Plugins      []plugin      `yaml:",omitempty"`
-	Consumers    []consumer    `yaml:",omitempty"`
+	Services     []Service     `yaml:",omitempty"`
+	Upstreams    []Upstream    `yaml:",omitempty"`
+	Certificates []Certificate `yaml:",omitempty"`
+	Plugins      []Plugin      `yaml:",omitempty"`
+	Consumers    []Consumer    `yaml:",omitempty"`
 }

--- a/file/writer.go
+++ b/file/writer.go
@@ -12,7 +12,8 @@ import (
 
 // KongStateToFile writes a state object to file with filename.
 // It will omit timestamps and IDs while writing.
-func KongStateToFile(kongState *state.KongState, filename string) error {
+func KongStateToFile(kongState *state.KongState,
+	selectTags []string, filename string) error {
 	var file fileStructure
 
 	services, err := kongState.Services.GetAll()
@@ -164,6 +165,7 @@ func KongStateToFile(kongState *state.KongState, filename string) error {
 		return strings.Compare(*file.Consumers[i].Username,
 			*file.Consumers[j].Username) < 0
 	})
+	file.Info.SelectorTags = selectTags
 
 	c, err := yaml.Marshal(file)
 	if err != nil {

--- a/file/writer.go
+++ b/file/writer.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/hbagdi/deck/state"
+	"github.com/hbagdi/deck/utils"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -34,6 +35,7 @@ func KongStateToFile(kongState *state.KongState,
 			p.ID = nil
 			p.CreatedAt = nil
 			p.Service = nil
+			utils.RemoveTags(&p.Plugin, selectTags)
 			s.Plugins = append(s.Plugins, &Plugin{Plugin: p.Plugin})
 		}
 		sort.SliceStable(s.Plugins, func(i, j int) bool {
@@ -49,10 +51,12 @@ func KongStateToFile(kongState *state.KongState,
 			r.CreatedAt = nil
 			r.UpdatedAt = nil
 			route := &Route{Route: r.Route}
+			utils.RemoveTags(&route.Route, selectTags)
 			for _, p := range plugins {
 				p.ID = nil
 				p.CreatedAt = nil
 				p.Route = nil
+				utils.RemoveTags(&p.Plugin, selectTags)
 				route.Plugins = append(route.Plugins, &Plugin{Plugin: p.Plugin})
 			}
 			sort.SliceStable(route.Plugins, func(i, j int) bool {
@@ -66,6 +70,7 @@ func KongStateToFile(kongState *state.KongState,
 		s.ID = nil
 		s.CreatedAt = nil
 		s.UpdatedAt = nil
+		utils.RemoveTags(&s.Service, selectTags)
 		file.Services = append(file.Services, s)
 	}
 	sort.SliceStable(file.Services, func(i, j int) bool {
@@ -83,6 +88,7 @@ func KongStateToFile(kongState *state.KongState,
 			p.ID = nil
 			p.CreatedAt = nil
 			p := Plugin{Plugin: p.Plugin}
+			utils.RemoveTags(&p.Plugin, selectTags)
 			file.Plugins = append(file.Plugins, p)
 		}
 	}
@@ -105,6 +111,7 @@ func KongStateToFile(kongState *state.KongState,
 			t.Upstream = nil
 			t.ID = nil
 			t.CreatedAt = nil
+			utils.RemoveTags(&t.Target, selectTags)
 			u.Targets = append(u.Targets, &Target{Target: t.Target})
 		}
 		sort.SliceStable(u.Targets, func(i, j int) bool {
@@ -113,6 +120,7 @@ func KongStateToFile(kongState *state.KongState,
 		})
 		u.ID = nil
 		u.CreatedAt = nil
+		utils.RemoveTags(&u.Upstream, selectTags)
 		file.Upstreams = append(file.Upstreams, u)
 	}
 	sort.SliceStable(file.Upstreams, func(i, j int) bool {
@@ -131,6 +139,7 @@ func KongStateToFile(kongState *state.KongState,
 		})
 		c.ID = nil
 		c.CreatedAt = nil
+		utils.RemoveTags(&c.Certificate, selectTags)
 		file.Certificates = append(file.Certificates, c)
 	}
 	sort.SliceStable(file.Certificates, func(i, j int) bool {
@@ -152,6 +161,7 @@ func KongStateToFile(kongState *state.KongState,
 			p.ID = nil
 			p.CreatedAt = nil
 			p.Consumer = nil
+			utils.RemoveTags(&p.Plugin, selectTags)
 			c.Plugins = append(c.Plugins, &Plugin{Plugin: p.Plugin})
 		}
 		sort.SliceStable(c.Plugins, func(i, j int) bool {
@@ -159,6 +169,7 @@ func KongStateToFile(kongState *state.KongState,
 		})
 		c.ID = nil
 		c.CreatedAt = nil
+		utils.RemoveTags(&c.Consumer, selectTags)
 		file.Consumers = append(file.Consumers, c)
 	}
 	sort.SliceStable(file.Consumers, func(i, j int) bool {

--- a/file/writer.go
+++ b/file/writer.go
@@ -14,14 +14,14 @@ import (
 // It will omit timestamps and IDs while writing.
 func KongStateToFile(kongState *state.KongState,
 	selectTags []string, filename string) error {
-	var file fileStructure
+	var file Content
 
 	services, err := kongState.Services.GetAll()
 	if err != nil {
 		return err
 	}
 	for _, s := range services {
-		s := service{Service: s.Service}
+		s := Service{Service: s.Service}
 		routes, err := kongState.Routes.GetAllByServiceID(*s.ID)
 		if err != nil {
 			return err
@@ -34,7 +34,7 @@ func KongStateToFile(kongState *state.KongState,
 			p.ID = nil
 			p.CreatedAt = nil
 			p.Service = nil
-			s.Plugins = append(s.Plugins, &plugin{Plugin: p.Plugin})
+			s.Plugins = append(s.Plugins, &Plugin{Plugin: p.Plugin})
 		}
 		sort.SliceStable(s.Plugins, func(i, j int) bool {
 			return strings.Compare(*s.Plugins[i].Name, *s.Plugins[j].Name) < 0
@@ -48,12 +48,12 @@ func KongStateToFile(kongState *state.KongState,
 			r.ID = nil
 			r.CreatedAt = nil
 			r.UpdatedAt = nil
-			route := &route{Route: r.Route}
+			route := &Route{Route: r.Route}
 			for _, p := range plugins {
 				p.ID = nil
 				p.CreatedAt = nil
 				p.Route = nil
-				route.Plugins = append(route.Plugins, &plugin{Plugin: p.Plugin})
+				route.Plugins = append(route.Plugins, &Plugin{Plugin: p.Plugin})
 			}
 			sort.SliceStable(route.Plugins, func(i, j int) bool {
 				return strings.Compare(*route.Plugins[i].Name, *route.Plugins[j].Name) < 0
@@ -82,7 +82,7 @@ func KongStateToFile(kongState *state.KongState,
 		if p.Consumer == nil && p.Service == nil && p.Route == nil {
 			p.ID = nil
 			p.CreatedAt = nil
-			p := plugin{Plugin: p.Plugin}
+			p := Plugin{Plugin: p.Plugin}
 			file.Plugins = append(file.Plugins, p)
 		}
 	}
@@ -96,7 +96,7 @@ func KongStateToFile(kongState *state.KongState,
 		return err
 	}
 	for _, u := range upstreams {
-		u := upstream{Upstream: u.Upstream}
+		u := Upstream{Upstream: u.Upstream}
 		targets, err := kongState.Targets.GetAllByUpstreamID(*u.ID)
 		if err != nil {
 			return err
@@ -105,7 +105,7 @@ func KongStateToFile(kongState *state.KongState,
 			t.Upstream = nil
 			t.ID = nil
 			t.CreatedAt = nil
-			u.Targets = append(u.Targets, &target{Target: t.Target})
+			u.Targets = append(u.Targets, &Target{Target: t.Target})
 		}
 		sort.SliceStable(u.Targets, func(i, j int) bool {
 			return strings.Compare(*u.Targets[i].Target.Target,
@@ -125,7 +125,7 @@ func KongStateToFile(kongState *state.KongState,
 		return err
 	}
 	for _, c := range certificates {
-		c := certificate{Certificate: c.Certificate}
+		c := Certificate{Certificate: c.Certificate}
 		sort.SliceStable(c.SNIs, func(i, j int) bool {
 			return strings.Compare(*c.SNIs[i], *c.SNIs[j]) < 0
 		})
@@ -143,7 +143,7 @@ func KongStateToFile(kongState *state.KongState,
 		return err
 	}
 	for _, c := range consumers {
-		c := consumer{Consumer: c.Consumer}
+		c := Consumer{Consumer: c.Consumer}
 		plugins, err := kongState.Plugins.GetAllByConsumerID(*c.ID)
 		if err != nil {
 			return err
@@ -152,7 +152,7 @@ func KongStateToFile(kongState *state.KongState,
 			p.ID = nil
 			p.CreatedAt = nil
 			p.Consumer = nil
-			c.Plugins = append(c.Plugins, &plugin{Plugin: p.Plugin})
+			c.Plugins = append(c.Plugins, &Plugin{Plugin: p.Plugin})
 		}
 		sort.SliceStable(c.Plugins, func(i, j int) bool {
 			return strings.Compare(*c.Plugins[i].Name, *c.Plugins[j].Name) < 0

--- a/file/writer_test.go
+++ b/file/writer_test.go
@@ -52,7 +52,7 @@ func TestWriteKongStateToStdoutEmptyState(t *testing.T) {
 	assert.Equal("-", filename)
 	assert.NotEmpty(t, ks)
 	output := captureOutput(func() {
-		KongStateToFile(ks, filename)
+		KongStateToFile(ks, nil, filename)
 	})
 	assert.Equal("{}\n", output)
 
@@ -67,7 +67,7 @@ func TestWriteKongStateToStdoutStateWithOneService(t *testing.T) {
 	service.Name = kong.String("my-service")
 	ks.Services.Add(service)
 	output := captureOutput(func() {
-		KongStateToFile(ks, filename)
+		KongStateToFile(ks, nil, filename)
 	})
 	fmt.Print(service.Host)
 	expected := fmt.Sprintf("services:\n- host: %s\n  name: %s\n", *service.Host, *service.Name)
@@ -96,7 +96,7 @@ func TestWriteKongStateToStdoutStateWithOneServiceOneRoute(t *testing.T) {
 	ks.Routes.Add(route)
 
 	output := captureOutput(func() {
-		KongStateToFile(ks, filename)
+		KongStateToFile(ks, nil, filename)
 	})
 	fmt.Print(service.Host)
 	expected := fmt.Sprintf(`services:

--- a/kong.yaml
+++ b/kong.yaml
@@ -1,6 +1,12 @@
+_info:
+  select_tags:
+  - managed-by-deck
+  - org-unit-42
 services:
 - name: svc1
   host: mockbin.org
+  tags:
+  - team-svc1
   routes:
   - name: r1
     paths:
@@ -75,6 +81,8 @@ certificates:
     hJCaXTsiP4IUmBjiwzSp3o1ctP8lWvnyJpAadYdDhaDaAAoaMjCo9cm5OMwc8t8x
     hwAPXV2cgWH8fPcT9NLAcwWk
     -----END PRIVATE KEY-----
+  tags:
+  - cloudops-managed
   snis:
   - demo1.example.com
   - demo2.example.com
@@ -83,35 +91,14 @@ plugins:
 - name: prometheus
   enabled: true
   run_on: first
-- name: request-transformer
-  config:
-    add:
-      body: []
-      headers:
-      - foo:bar
-      querystring: []
-    append:
-      body: []
-      headers: []
-      querystring: []
-    http_method: null
-    remove:
-      body: []
-      headers: []
-      querystring: []
-    rename:
-      body: []
-      headers: []
-      querystring: []
-    replace:
-      body: []
-      headers: []
-      querystring: []
-  enabled: true
-  run_on: first
+  protocols:
+  - http
+  - https
 consumers:
 - username: harry
 - username: yolo
+  tags:
+  - internal-user
   plugins:
   - name: rate-limiting
     config:
@@ -132,3 +119,6 @@ consumers:
       year: null
     enabled: true
     run_on: first
+    protocols:
+    - http
+    - https

--- a/utils/tags.go
+++ b/utils/tags.go
@@ -1,0 +1,69 @@
+package utils
+
+import (
+	"reflect"
+
+	"github.com/pkg/errors"
+)
+
+// MergeTags merges Tags in the object with tags.
+func MergeTags(obj interface{}, tags []string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+	ptr := reflect.ValueOf(obj)
+	if ptr.Kind() != reflect.Ptr {
+		return errors.New("obj is not a pointer")
+	}
+	v := reflect.Indirect(ptr)
+	structTags := v.FieldByName("Tags")
+	var zero reflect.Value
+	if structTags == zero {
+		return nil
+	}
+	m := make(map[string]bool)
+	for i := 0; i < structTags.Len(); i++ {
+		tag := reflect.Indirect(structTags.Index(i)).String()
+		m[tag] = true
+	}
+	for _, tag := range tags {
+		if _, ok := m[tag]; !ok {
+			t := tag
+			structTags.Set(reflect.Append(structTags, reflect.ValueOf(&t)))
+		}
+	}
+	return nil
+}
+
+// RemoveTags removes tags from the Tags in obj.
+func RemoveTags(obj interface{}, tags []string) error {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	m := make(map[string]bool)
+	for _, tag := range tags {
+		m[tag] = true
+	}
+
+	ptr := reflect.ValueOf(obj)
+	if ptr.Kind() != reflect.Ptr {
+		return errors.New("obj is not a pointer")
+	}
+	v := reflect.Indirect(ptr)
+	structTags := v.FieldByName("Tags")
+	var zero reflect.Value
+	if structTags == zero {
+		return nil
+	}
+
+	res := reflect.MakeSlice(reflect.SliceOf(reflect.PtrTo(reflect.TypeOf(""))), 0, 0)
+	for i := 0; i < structTags.Len(); i++ {
+		tag := reflect.Indirect(structTags.Index(i)).String()
+		if !m[tag] {
+			res = reflect.Append(res, structTags.Index(i))
+		}
+	}
+	structTags.Set(res)
+	return nil
+}

--- a/utils/tags_test.go
+++ b/utils/tags_test.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeTags(t *testing.T) {
+	type Foo struct {
+		Tags []*string
+	}
+	type Bar struct{}
+
+	assert := assert.New(t)
+
+	a := "tag1"
+	b := "tag2"
+	c := "tag3"
+
+	var f Foo
+	err := MergeTags(f, []string{"tag1"})
+	assert.NotNil(err)
+
+	var bar Bar
+	err = MergeTags(&bar, []string{"tag1"})
+	assert.Nil(err)
+
+	f = Foo{Tags: []*string{&a, &b}}
+	MergeTags(&f, []string{"tag1", "tag2", "tag3"})
+	assert.True(equalArray([]*string{&a, &b, &c}, f.Tags))
+
+	f = Foo{Tags: []*string{}}
+	MergeTags(&f, []string{"tag1", "tag2", "tag3"})
+	assert.True(equalArray([]*string{&a, &b, &c}, f.Tags))
+
+	f = Foo{Tags: []*string{&a, &b}}
+	MergeTags(&f, nil)
+	assert.True(equalArray([]*string{&a, &b}, f.Tags))
+}
+
+func equalArray(want, have []*string) bool {
+	if len(want) != len(have) {
+		return false
+	}
+	for i := 0; i < len(want); i++ {
+		if *want[i] != *have[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestRemoveTags(t *testing.T) {
+	type Foo struct {
+		Tags []*string
+	}
+	type Bar struct{}
+
+	assert := assert.New(t)
+
+	a := "tag1"
+	b := "tag2"
+
+	var f Foo
+	err := RemoveTags(f, []string{"tag1"})
+	assert.NotNil(err)
+
+	var bar Bar
+	err = RemoveTags(&bar, []string{"tag1"})
+	assert.Nil(err)
+
+	f = Foo{Tags: []*string{&a, &b}}
+	RemoveTags(&f, []string{"tag2", "tag3"})
+	assert.True(equalArray([]*string{&a}, f.Tags))
+
+	f = Foo{Tags: []*string{}}
+	RemoveTags(&f, []string{"tag1", "tag2", "tag3"})
+	assert.True(equalArray([]*string{}, f.Tags))
+
+	f = Foo{Tags: []*string{&a, &b}}
+	RemoveTags(&f, nil)
+	assert.True(equalArray([]*string{&a, &b}, f.Tags))
+}


### PR DESCRIPTION
Entities in Kong's DB can be managed using multiple configuration file.
Each file can have a `select-tag` which can be used to shard entities in Kong.

To ease on-boarding, users can create different state file using the `dump` command, which can export only a subset of all Kong entities, which are sharing a (set of) common tags.