### PR TITLE
fix(default) allow strip_path to be set to false

### DIFF
--- a/utils/constants.go
+++ b/utils/constants.go
@@ -15,7 +15,7 @@ var (
 	routeDefaults = kong.Route{
 		PreserveHost:  kong.Bool(false),
 		RegexPriority: kong.Int(0),
-		StripPath:     kong.Bool(true),
+		StripPath:     kong.Bool(false),
 		Protocols:     kong.StringSlice("http", "https"),
 	}
 	targetDefaults = kong.Target{

--- a/utils/defaulter_test.go
+++ b/utils/defaulter_test.go
@@ -144,7 +144,7 @@ func TestRouteSetTest(t *testing.T) {
 			want: &kong.Route{
 				PreserveHost:  kong.Bool(true),
 				RegexPriority: kong.Int(0),
-				StripPath:     kong.Bool(true),
+				StripPath:     kong.Bool(false),
 				Protocols:     kong.StringSlice("http", "https"),
 			},
 		},
@@ -156,7 +156,7 @@ func TestRouteSetTest(t *testing.T) {
 			want: &kong.Route{
 				PreserveHost:  kong.Bool(false),
 				RegexPriority: kong.Int(0),
-				StripPath:     kong.Bool(true),
+				StripPath:     kong.Bool(false),
 				Protocols:     kong.StringSlice("http", "tls"),
 			},
 		},
@@ -172,6 +172,30 @@ func TestRouteSetTest(t *testing.T) {
 				Name:          kong.String("foo"),
 				Hosts:         kong.StringSlice("1.example.com", "2.example.com"),
 				Methods:       kong.StringSlice("GET", "POST"),
+				PreserveHost:  kong.Bool(false),
+				RegexPriority: kong.Int(0),
+				StripPath:     kong.Bool(false),
+				Protocols:     kong.StringSlice("http", "https"),
+			},
+		},
+		{
+			desc: "strip-path can be set to false",
+			arg: &kong.Route{
+				StripPath: kong.Bool(false),
+			},
+			want: &kong.Route{
+				PreserveHost:  kong.Bool(false),
+				RegexPriority: kong.Int(0),
+				StripPath:     kong.Bool(false),
+				Protocols:     kong.StringSlice("http", "https"),
+			},
+		},
+		{
+			desc: "strip-path can be set to true",
+			arg: &kong.Route{
+				StripPath: kong.Bool(true),
+			},
+			want: &kong.Route{
 				PreserveHost:  kong.Bool(false),
 				RegexPriority: kong.Int(0),
 				StripPath:     kong.Bool(true),


### PR DESCRIPTION
Breaking change:

This is a limitation of how we fill in default values for the missing
values. It is not possible in Go to determine if a value is nil vs a
zero vaule (false for boolean).

Fixes #18