### PR TITLE
Dockerfile - add decK to path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN go mod download
 ADD . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o deck
 
-FROM alpine:3.9
+FROM alpine:3.10
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=build /deck .
-ENTRYPOINT ["./deck"]
+COPY --from=build /deck/deck /usr/local/bin
+ENTRYPOINT ["deck"]


### PR DESCRIPTION
Current Dockerfile builds under `/deck` directory the `deck` binary, then adds the full directory with all source code to the image, then calls deck inside that directory.

The proposed change does the following:
- upgrade to latest `alpine` image, currently 3.10
- copies only the `deck` binary into the final image at `/usr/local/bin` so it can be in the `PATH`
- uses just `deck` as the entrypoint since it's in the `PATH`