### PR TITLE
fix(state): use upstreamIDTarget index instead of target

### DIFF
--- a/diff/diffTarget.go
+++ b/diff/diffTarget.go
@@ -36,7 +36,7 @@ func (sc *Syncer) deleteTarget(target *state.Target) (*Event, error) {
 			target)
 	}
 	// lookup by Name
-	_, err := sc.targetState.Targets.Get(*target.Target.Target)
+	_, err := sc.targetState.Targets.GetByUpstreamIDAndTarget(*target.Upstream.ID, *target.Target.Target)
 	if err == state.ErrNotFound {
 		return &Event{
 			Op:   crud.Delete,
@@ -74,7 +74,7 @@ func (sc *Syncer) createUpdateTargets() error {
 
 func (sc *Syncer) createUpdateTarget(target *state.Target) (*Event, error) {
 	target = &state.Target{Target: *target.DeepCopy()}
-	currentTarget, err := sc.currentState.Targets.Get(*target.Target.Target)
+	currentTarget, err := sc.currentState.Targets.GetByUpstreamIDAndTarget(*target.Upstream.ID, *target.Target.Target)
 	if err == state.ErrNotFound {
 		// target not present, create it
 

--- a/file/reader.go
+++ b/file/reader.go
@@ -175,7 +175,7 @@ func GetStateFromContent(fileContent *Content) (*state.KongState,
 				t.ID = kong.String("placeholder-" +
 					strconv.FormatUint(count.Inc(), 10))
 			}
-			_, err := kongState.Targets.Get(*t.Target.Target)
+			_, err := kongState.Targets.GetByUpstreamIDAndTarget(*u.ID, *t.Target.Target)
 			if err != state.ErrNotFound {
 				return nil, nil, "", errors.Errorf("duplicate target definitions"+
 					" found for: '%s'", *t.Target.Target)


### PR DESCRIPTION
Related issue https://github.com/hbagdi/deck/issues/57

Remove the unique `target` index in `TargetsCollection`, replace it with a union index of (`upstreamID`, `target`). Allow different upstreams to share same targets.

I know this PR may break calls of `TargetsCollection.Get` outside this repo. But I checked the `kubernetes-ingress-controller` repo and there's no direct usage of `TargetsCollection`. So I think it might ok.

As a fan of Kong, we're considering using the office kubernetes-ingress-controller to replace our version. So truly appreciated if you can take a look at this PR. Thanks.