### PR TITLE
feat(file) implement JSON file reader/writer

### DIFF
--- a/file/reader.go
+++ b/file/reader.go
@@ -16,7 +16,7 @@ var count counter.Counter
 // GetStateFromFile reads in a file with filename and constructs
 // a state. If filename is `-`, then it will read from os.Stdin.
 // If filename represents a directory, it will traverse the tree
-// rooted at filename, read all the files with .yaml and .yml extensions
+// rooted at filename, read all the files with .yaml, .yml and .json extensions
 // and generate a state after a merge of the content from all the files.
 //
 // It will return an error if the file representation is invalid
@@ -49,7 +49,10 @@ func GetStateFromContent(fileContent *Content) (*state.KongState,
 	if err != nil {
 		return nil, nil, "", errors.Wrap(err, "creating defaulter")
 	}
-	selectTags := fileContent.Info.SelectorTags
+	var selectTags []string
+	if fileContent.Info != nil {
+		selectTags = fileContent.Info.SelectorTags
+	}
 	workspace := fileContent.Workspace
 	kongState, err := state.NewKongState()
 	if err != nil {
@@ -415,7 +418,7 @@ func GetStateFromContent(fileContent *Content) (*state.KongState,
 		}
 	}
 
-	return kongState, fileContent.Info.SelectorTags, workspace, nil
+	return kongState, selectTags, workspace, nil
 }
 
 func processPlugin(p *Plugin, tags []string) (bool, error) {

--- a/file/readfile.go
+++ b/file/readfile.go
@@ -13,7 +13,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-// getContent reads reads all the YAML files in the directory or the
+// getContent reads reads all the YAML and JSON files in the directory or the
 // file, depending on what fileOrDir represents, merges the content of
 // these files and renders a Content.
 func getContent(fileOrDir string) (*Content, error) {
@@ -35,7 +35,7 @@ func getContent(fileOrDir string) (*Content, error) {
 	return &res, nil
 }
 
-// getReaders returns back io.Readers representing all the YAML
+// getReaders returns back io.Readers representing all the YAML and JSON
 // files in a directory. If fileOrDir is a single file, then it
 // returns back the reader for the file.
 // If fileOrDir is equal to "-" string, then it returns back a io.Reader
@@ -53,10 +53,10 @@ func getReaders(fileOrDir string) ([]io.Reader, error) {
 
 	var files []string
 	if finfo.IsDir() {
-		files, err = yamlFilesInDir(fileOrDir)
+		files, err = configFilesInDir(fileOrDir)
 		if err != nil {
 			return nil,
-				errors.Wrap(err, "getting YAML files from directory")
+				errors.Wrap(err, "getting files from directory")
 		}
 	} else {
 		files = append(files, fileOrDir)
@@ -90,11 +90,11 @@ func readContent(reader io.Reader) (*Content, error) {
 	return &content, nil
 }
 
-// yamlFilesInDir traverses the directory rooted at dir and
+// configFilesInDir traverses the directory rooted at dir and
 // returns all the files with a case-insensitive extension of `yml` or `yaml`.
-func yamlFilesInDir(dir string) ([]string, error) {
+func configFilesInDir(dir string) ([]string, error) {
 	var res []string
-	yamlExt := regexp.MustCompile("[Yy]([Aa])?[Mm][Ll]")
+	exts := regexp.MustCompile("[Yy]([Aa])?[Mm][Ll]|[Jj][Ss][Oo][Nn]")
 	err := filepath.Walk(
 		dir,
 		func(path string, info os.FileInfo, err error) error {
@@ -104,7 +104,7 @@ func yamlFilesInDir(dir string) ([]string, error) {
 			if info.IsDir() {
 				return nil
 			}
-			if yamlExt.MatchString(path) {
+			if exts.MatchString(path) {
 				res = append(res, path)
 			}
 			return nil

--- a/file/readfile_test.go
+++ b/file/readfile_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hbagdi/go-kong/kong"
 )
 
-func Test_yamlFilesInDir(t *testing.T) {
+func Test_configFilesInDir(t *testing.T) {
 	type args struct {
 		dir string
 	}
@@ -38,19 +38,20 @@ func Test_yamlFilesInDir(t *testing.T) {
 				"testdata/emptyfiles/Baz.YamL",
 				"testdata/emptyfiles/bar.yaml",
 				"testdata/emptyfiles/foo.yml",
+				"testdata/emptyfiles/foobar.json",
 			},
 			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := yamlFilesInDir(tt.args.dir)
+			got, err := configFilesInDir(tt.args.dir)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("yamlFilesInDir() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("configFilesInDir() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("yamlFilesInDir() = %v, want %v", got, tt.want)
+				t.Errorf("configFilesInDir() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -86,12 +87,19 @@ func Test_getReaders(t *testing.T) {
 			name:    "valid directory",
 			args:    args{"testdata/emptyfiles"},
 			want:    nil,
-			wantLen: 3,
+			wantLen: 4,
 			wantErr: false,
 		},
 		{
 			name:    "valid file",
 			args:    args{"testdata/file.yaml"},
+			want:    nil,
+			wantLen: 1,
+			wantErr: false,
+		},
+		{
+			name:    "valid JSON file",
+			args:    args{"testdata/file.json"},
 			want:    nil,
 			wantLen: 1,
 			wantErr: false,
@@ -151,6 +159,12 @@ func Test_getContent(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "bad JSON",
+			args:    args{"testdata/badjson"},
+			want:    nil,
+			wantErr: true,
+		},
+		{
 			name: "single file",
 			args: args{"testdata/file.yaml"},
 			want: &Content{
@@ -184,7 +198,7 @@ func Test_getContent(t *testing.T) {
 			name: "valid directory",
 			args: args{"testdata/valid"},
 			want: &Content{
-				Info: Info{
+				Info: &Info{
 					SelectorTags: []string{"tag1"},
 				},
 				Services: []Service{
@@ -219,6 +233,16 @@ func Test_getContent(t *testing.T) {
 					},
 				},
 				Consumers: []Consumer{
+					{
+						Consumer: kong.Consumer{
+							Username: kong.String("foo"),
+						},
+					},
+					{
+						Consumer: kong.Consumer{
+							Username: kong.String("bar"),
+						},
+					},
 					{
 						Consumer: kong.Consumer{
 							Username: kong.String("harry"),

--- a/file/testdata/badjson/foo.json
+++ b/file/testdata/badjson/foo.json
@@ -1,0 +1,13 @@
+{
+  "services": {
+    "foo": "bar"
+  },
+  "consumers": [
+    {
+      "username": "foo"
+    },
+    {
+      "username": "bar"
+    }
+  ]
+}

--- a/file/testdata/file.json
+++ b/file/testdata/file.json
@@ -1,0 +1,10 @@
+{
+  "consumers": [
+    {
+      "username": "foo"
+    },
+    {
+      "username": "bar"
+    }
+  ]
+}

--- a/file/testdata/valid/consumers.json
+++ b/file/testdata/valid/consumers.json
@@ -1,0 +1,10 @@
+{
+  "consumers": [
+    {
+      "username": "foo"
+    },
+    {
+      "username": "bar"
+    }
+  ]
+}

--- a/file/types.go
+++ b/file/types.go
@@ -2,23 +2,33 @@ package file
 
 import "github.com/hbagdi/go-kong/kong"
 
+// Format is a file format for Kong's configuration.
+type Format string
+
+const (
+	// JSON is JSON file format.
+	JSON = "JSON"
+	// YAML if YAML file format.
+	YAML = "YAML"
+)
+
 // Service represents a Kong Service and it's associated routes and plugins.
 type Service struct {
 	kong.Service `yaml:",inline,omitempty"`
-	Routes       []*Route  `yaml:",omitempty"`
-	Plugins      []*Plugin `yaml:",omitempty"`
+	Routes       []*Route  `json:"routes,omitempty" yaml:",omitempty"`
+	Plugins      []*Plugin `json:"plugins,omitempty" yaml:",omitempty"`
 }
 
 // Route represents a Kong Route and it's associated plugins.
 type Route struct {
 	kong.Route `yaml:",inline,omitempty"`
-	Plugins    []*Plugin `yaml:",omitempty"`
+	Plugins    []*Plugin `json:"plugins,omitempty" yaml:",omitempty"`
 }
 
 // Upstream represents a Kong Upstream and it's associated targets.
 type Upstream struct {
 	kong.Upstream `yaml:",inline,omitempty"`
-	Targets       []*Target `yaml:",omitempty"`
+	Targets       []*Target `json:"targets,omitempty" yaml:",omitempty"`
 }
 
 // Target represents a Kong Target.
@@ -44,29 +54,29 @@ type Plugin struct {
 // Consumer represents a consumer in Kong.
 type Consumer struct {
 	kong.Consumer `yaml:",inline,omitempty"`
-	Plugins       []*Plugin                `yaml:",omitempty"`
-	KeyAuths      []*kong.KeyAuth          `yaml:"keyauth_credentials,omitempty"`
-	HMACAuths     []*kong.HMACAuth         `yaml:"hmacauth_credentials,omitempty"`
-	JWTAuths      []*kong.JWTAuth          `yaml:"jwt_secrets,omitempty"`
-	BasicAuths    []*kong.BasicAuth        `yaml:"basicauth_credentials,omitempty"`
-	Oauth2Creds   []*kong.Oauth2Credential `yaml:"oauth2_credentials,omitempty"`
-	ACLGroups     []*kong.ACLGroup         `yaml:"acls,omitempty"`
+	Plugins       []*Plugin                `json:"plugins,omitempty" yaml:",omitempty"`
+	KeyAuths      []*kong.KeyAuth          `json:"keyauth_credentials,omitempty" yaml:"keyauth_credentials,omitempty"`
+	HMACAuths     []*kong.HMACAuth         `json:"hmacauth_credentials,omitempty" yaml:"hmacauth_credentials,omitempty"`
+	JWTAuths      []*kong.JWTAuth          `json:"jwt_secrets,omitempty" yaml:"jwt_secrets,omitempty"`
+	BasicAuths    []*kong.BasicAuth        `json:"basicauth_credentials,omitempty" yaml:"basicauth_credentials,omitempty"`
+	Oauth2Creds   []*kong.Oauth2Credential `json:"oauth2_credentials,omitempty" yaml:"oauth2_credentials,omitempty"`
+	ACLGroups     []*kong.ACLGroup         `json:"acls,omitempty" yaml:"acls,omitempty"`
 }
 
 // Info contains meta-data of the file.
 type Info struct {
-	SelectorTags []string `yaml:"select_tags,omitempty"`
+	SelectorTags []string `json:"select_tags,omitempty" yaml:"select_tags,omitempty"`
 }
 
 // Content represents a serialized Kong state.
 type Content struct {
-	FormatVersion  string          `yaml:"_format_version,omitempty"`
-	Info           Info            `yaml:"_info,omitempty"`
-	Workspace      string          `yaml:"_workspace,omitempty"`
-	Services       []Service       `yaml:",omitempty"`
-	Upstreams      []Upstream      `yaml:",omitempty"`
-	Certificates   []Certificate   `yaml:",omitempty"`
-	CACertificates []CACertificate `yaml:"ca_certificates,omitempty"`
-	Plugins        []Plugin        `yaml:",omitempty"`
-	Consumers      []Consumer      `yaml:",omitempty"`
+	FormatVersion  string          `json:"_format_version,omitempty" yaml:"_format_version,omitempty"`
+	Info           *Info           `json:"_info,omitempty" yaml:"_info,omitempty"`
+	Workspace      string          `json:"_workspace,omitempty" yaml:"_workspace,omitempty"`
+	Services       []Service       `json:"services,omitempty" yaml:",omitempty"`
+	Upstreams      []Upstream      `json:"upstreams,omitempty" yaml:",omitempty"`
+	Certificates   []Certificate   `json:"certificates,omitempty" yaml:",omitempty"`
+	CACertificates []CACertificate `json:"ca_certificates,omitempty" yaml:"ca_certificates,omitempty"`
+	Plugins        []Plugin        `json:"plugins,omitempty" yaml:",omitempty"`
+	Consumers      []Consumer      `json:"consumers,omitempty" yaml:",omitempty"`
 }


### PR DESCRIPTION
decK can now export Kong's configuration in JSON format, in addition to
the YAML format.

This can be configured using `--format` flag on the `dump` command.

Input can also be JSON.

Fix #35