### PR TITLE
refactor(state) consolidate multiple memdbs into a single one

### DIFF
--- a/state/aclgroup_test.go
+++ b/state/aclgroup_test.go
@@ -7,16 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func aclGroupsCollection() *ACLGroupsCollection {
+	return state().ACLGroups
+}
+
 func TestACLGroupInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewACLGroupsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := aclGroupsCollection()
 
 	var aclGroup ACLGroup
 	aclGroup.Group = kong.String("my-group")
 	aclGroup.ID = kong.String("first")
-	err = collection.Add(aclGroup)
+	err := collection.Add(aclGroup)
 	assert.NotNil(err)
 
 	var aclGroup2 ACLGroup
@@ -32,9 +34,7 @@ func TestACLGroupInsert(t *testing.T) {
 
 func TestACLGroupGetByID(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewACLGroupsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := aclGroupsCollection()
 
 	var aclGroup ACLGroup
 	aclGroup.Group = kong.String("my-group")
@@ -44,7 +44,7 @@ func TestACLGroupGetByID(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(aclGroup)
+	err := collection.Add(aclGroup)
 	assert.Nil(err)
 
 	res, err := collection.GetByID("first")
@@ -63,9 +63,7 @@ func TestACLGroupGetByID(t *testing.T) {
 
 func TestACLGroupGet(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewACLGroupsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := aclGroupsCollection()
 
 	populateWithACLGroupFixtures(assert, collection)
 
@@ -84,9 +82,7 @@ func TestACLGroupGet(t *testing.T) {
 
 func TestACLGroupUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewACLGroupsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := aclGroupsCollection()
 
 	var aclGroup ACLGroup
 	aclGroup.Group = kong.String("my-group")
@@ -96,7 +92,7 @@ func TestACLGroupUpdate(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(aclGroup)
+	err := collection.Add(aclGroup)
 	assert.Nil(err)
 
 	res, err := collection.Get("consumer1-id", "first")
@@ -118,9 +114,7 @@ func TestACLGroupUpdate(t *testing.T) {
 
 func TestACLGroupDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewACLGroupsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := aclGroupsCollection()
 
 	var aclGroup ACLGroup
 	aclGroup.Group = kong.String("my-group1")
@@ -129,7 +123,7 @@ func TestACLGroupDelete(t *testing.T) {
 		ID:       kong.String("consumer1-id"),
 		Username: kong.String("consumer1-name"),
 	}
-	err = collection.Add(aclGroup)
+	err := collection.Add(aclGroup)
 	assert.Nil(err)
 
 	res, err := collection.Get("consumer1-name", "my-group1")
@@ -153,9 +147,7 @@ func TestACLGroupDelete(t *testing.T) {
 
 func TestACLGroupGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewACLGroupsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := aclGroupsCollection()
 
 	populateWithACLGroupFixtures(assert, collection)
 
@@ -166,9 +158,7 @@ func TestACLGroupGetAll(t *testing.T) {
 
 func TestACLGroupGetByConsumer(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewACLGroupsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := aclGroupsCollection()
 
 	populateWithACLGroupFixtures(assert, collection)
 

--- a/state/basicauth_test.go
+++ b/state/basicauth_test.go
@@ -7,15 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func basicAuthsCollection() *BasicAuthsCollection {
+	return state().BasicAuths
+}
+
 func TestBasicAuthInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewBasicAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := basicAuthsCollection()
 
 	var basicAuth BasicAuth
 	basicAuth.ID = kong.String("first")
-	err = collection.Add(basicAuth)
+	err := collection.Add(basicAuth)
 	assert.NotNil(err)
 
 	basicAuth.Username = kong.String("my-username")
@@ -35,9 +37,7 @@ func TestBasicAuthInsert(t *testing.T) {
 
 func TestBasicAuthGet(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewBasicAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := basicAuthsCollection()
 
 	var basicAuth BasicAuth
 	basicAuth.Username = kong.String("my-username")
@@ -47,7 +47,7 @@ func TestBasicAuthGet(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(basicAuth)
+	err := collection.Add(basicAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("first")
@@ -68,9 +68,7 @@ func TestBasicAuthGet(t *testing.T) {
 
 func TestBasicAuthUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewBasicAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := basicAuthsCollection()
 
 	var basicAuth BasicAuth
 	basicAuth.Username = kong.String("my-username")
@@ -80,7 +78,7 @@ func TestBasicAuthUpdate(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(basicAuth)
+	err := collection.Add(basicAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("first")
@@ -104,9 +102,7 @@ func TestBasicAuthUpdate(t *testing.T) {
 
 func TestBasicAuthDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewBasicAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := basicAuthsCollection()
 
 	var basicAuth BasicAuth
 	basicAuth.Username = kong.String("my-username1")
@@ -115,7 +111,7 @@ func TestBasicAuthDelete(t *testing.T) {
 		ID:       kong.String("consumer1-id"),
 		Username: kong.String("consumer1-name"),
 	}
-	err = collection.Add(basicAuth)
+	err := collection.Add(basicAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("my-username1")
@@ -139,9 +135,7 @@ func TestBasicAuthDelete(t *testing.T) {
 
 func TestBasicAuthGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewBasicAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := basicAuthsCollection()
 
 	populateWithBasicAuthFixtures(assert, collection)
 
@@ -152,9 +146,7 @@ func TestBasicAuthGetAll(t *testing.T) {
 
 func TestBasicAuthGetByConsumer(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewBasicAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := basicAuthsCollection()
 
 	populateWithBasicAuthFixtures(assert, collection)
 

--- a/state/cacert_test.go
+++ b/state/cacert_test.go
@@ -7,16 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func caCertsCollection() *CACertificatesCollection {
+	return state().CACertificates
+}
+
 func TestCACertificateInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewCACertificatesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := caCertsCollection()
 
 	var caCert CACertificate
 	caCert.ID = kong.String("first")
 	caCert.Cert = kong.String("firstCert")
-	err = collection.Add(caCert)
+	err := collection.Add(caCert)
 	assert.Nil(err)
 
 	err = collection.Add(caCert)
@@ -25,14 +27,12 @@ func TestCACertificateInsert(t *testing.T) {
 
 func TestCACertificateGetUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewCACertificatesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := caCertsCollection()
 
 	var caCert CACertificate
 	caCert.Cert = kong.String("firstCert")
 	caCert.ID = kong.String("first")
-	err = collection.Add(caCert)
+	err := collection.Add(caCert)
 	assert.Nil(err)
 
 	se, err := collection.Get("firstCert")
@@ -54,14 +54,12 @@ func TestCACertificateGetUpdate(t *testing.T) {
 
 func TestCACertificateDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewCACertificatesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := caCertsCollection()
 
 	var caCert CACertificate
 	caCert.ID = kong.String("first")
 	caCert.Cert = kong.String("firstCert")
-	err = collection.Add(caCert)
+	err := collection.Add(caCert)
 	assert.Nil(err)
 
 	se, err := collection.Get("first")
@@ -94,14 +92,12 @@ func TestCACertificateDelete(t *testing.T) {
 
 func TestCACertificateGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewCACertificatesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := caCertsCollection()
 
 	var caCert CACertificate
 	caCert.ID = kong.String("first")
 	caCert.Cert = kong.String("firstCert")
-	err = collection.Add(caCert)
+	err := collection.Add(caCert)
 	assert.Nil(err)
 
 	var certificate2 CACertificate

--- a/state/certificate_test.go
+++ b/state/certificate_test.go
@@ -7,31 +7,31 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func certsCollection() *CertificatesCollection {
+	return state().Certificates
+}
+
 func TestCertificateInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewCertificatesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := certsCollection()
 
 	var certificate Certificate
 	certificate.ID = kong.String("first")
 	certificate.Cert = kong.String("firstCert")
 	certificate.Key = kong.String("firstKey")
-	err = collection.Add(certificate)
+	err := collection.Add(certificate)
 	assert.Nil(err)
 }
 
 func TestCertificateGetUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewCertificatesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := certsCollection()
 
 	var certificate Certificate
 	certificate.Cert = kong.String("firstCert")
 	certificate.Key = kong.String("firstKey")
 	certificate.ID = kong.String("first")
-	err = collection.Add(certificate)
+	err := collection.Add(certificate)
 	assert.Nil(err)
 
 	se, err := collection.GetByCertKey("firstCert", "firstKey")
@@ -56,14 +56,13 @@ func TestCertificateGetUpdate(t *testing.T) {
 // is different from the one stored in MemDB.
 func TestCertificateGetMemoryReference(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewCertificatesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := certsCollection()
+
 	var cert Certificate
 	cert.Cert = kong.String("my-cert")
 	cert.Key = kong.String("my-key")
 	cert.ID = kong.String("first")
-	err = collection.Add(cert)
+	err := collection.Add(cert)
 	assert.Nil(err)
 
 	c, err := collection.Get("first")
@@ -79,16 +78,13 @@ func TestCertificateGetMemoryReference(t *testing.T) {
 
 func TestCertificatesInvalidType(t *testing.T) {
 	assert := assert.New(t)
-
-	collection, err := NewCertificatesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := certsCollection()
 
 	var upstream Upstream
 	upstream.Name = kong.String("my-upstream")
 	upstream.ID = kong.String("first")
-	txn := collection.memdb.Txn(true)
-	err = txn.Insert(certificateTableName, &upstream)
+	txn := collection.db.Txn(true)
+	err := txn.Insert(certificateTableName, &upstream)
 	assert.NotNil(err)
 	txn.Abort()
 
@@ -105,7 +101,7 @@ func TestCertificatesInvalidType(t *testing.T) {
 		},
 	}
 
-	txn = collection.memdb.Txn(true)
+	txn = collection.db.Txn(true)
 	err = txn.Insert(certificateTableName, &certificate)
 	assert.Nil(err)
 	txn.Commit()
@@ -121,15 +117,13 @@ func TestCertificatesInvalidType(t *testing.T) {
 
 func TestCertificateDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewCertificatesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := certsCollection()
 
 	var certificate Certificate
 	certificate.ID = kong.String("first")
 	certificate.Cert = kong.String("firstCert")
 	certificate.Key = kong.String("firstKey")
-	err = collection.Add(certificate)
+	err := collection.Add(certificate)
 	assert.Nil(err)
 
 	se, err := collection.Get("first")
@@ -163,15 +157,13 @@ func TestCertificateDelete(t *testing.T) {
 
 func TestCertificateGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewCertificatesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := certsCollection()
 
 	var certificate Certificate
 	certificate.ID = kong.String("first")
 	certificate.Cert = kong.String("firstCert")
 	certificate.Key = kong.String("firstKey")
-	err = collection.Add(certificate)
+	err := collection.Add(certificate)
 	assert.Nil(err)
 
 	var certificate2 Certificate

--- a/state/consumer_test.go
+++ b/state/consumer_test.go
@@ -7,28 +7,29 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func consumersCollection() *ConsumersCollection {
+	return state().Consumers
+}
+
 func TestConsumerInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewConsumersCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := consumersCollection()
+
 	var consumer Consumer
 	consumer.ID = kong.String("first")
 	consumer.Username = kong.String("my-name")
-	err = collection.Add(consumer)
+	err := collection.Add(consumer)
 	assert.Nil(err)
 }
 
 func TestConsumerGetUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewConsumersCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := consumersCollection()
 
 	var consumer Consumer
 	consumer.ID = kong.String("first")
 	consumer.Username = kong.String("my-name")
-	err = collection.Add(consumer)
+	err := collection.Add(consumer)
 	assert.Nil(err)
 
 	c, err := collection.Get("first")
@@ -51,14 +52,12 @@ func TestConsumerGetUpdate(t *testing.T) {
 // is different from the one stored in MemDB.
 func TestConsumerGetMemoryReference(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewConsumersCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := consumersCollection()
 
 	var consumer Consumer
 	consumer.ID = kong.String("first")
 	consumer.Username = kong.String("my-name")
-	err = collection.Add(consumer)
+	err := collection.Add(consumer)
 	assert.Nil(err)
 
 	c, err := collection.Get("first")
@@ -73,16 +72,13 @@ func TestConsumerGetMemoryReference(t *testing.T) {
 
 func TestConsumersInvalidType(t *testing.T) {
 	assert := assert.New(t)
-
-	collection, err := NewConsumersCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := consumersCollection()
 
 	type c2 Consumer
 	var c c2
 	c.Username = kong.String("my-name")
 	c.ID = kong.String("first")
-	txn := collection.memdb.Txn(true)
+	txn := collection.db.Txn(true)
 	assert.Nil(txn.Insert(consumerTableName, &c))
 	txn.Commit()
 
@@ -96,14 +92,12 @@ func TestConsumersInvalidType(t *testing.T) {
 
 func TestConsumerDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewConsumersCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := consumersCollection()
 
 	var consumer Consumer
 	consumer.ID = kong.String("first")
 	consumer.Username = kong.String("my-consumer")
-	err = collection.Add(consumer)
+	err := collection.Add(consumer)
 	assert.Nil(err)
 
 	c, err := collection.Get("my-consumer")
@@ -120,9 +114,7 @@ func TestConsumerDelete(t *testing.T) {
 
 func TestConsumerGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewConsumersCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := consumersCollection()
 
 	consumers := []Consumer{
 		{

--- a/state/hmacauth_test.go
+++ b/state/hmacauth_test.go
@@ -7,15 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func hmacAuthsCollection() *HMACAuthsCollection {
+	return state().HMACAuths
+}
+
 func TestHMACAuthInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewHMACAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := hmacAuthsCollection()
 
 	var hmacAuth HMACAuth
 	hmacAuth.ID = kong.String("first")
-	err = collection.Add(hmacAuth)
+	err := collection.Add(hmacAuth)
 	assert.NotNil(err)
 
 	hmacAuth.Username = kong.String("my-username")
@@ -35,9 +37,7 @@ func TestHMACAuthInsert(t *testing.T) {
 
 func TestHMACAuthGet(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewHMACAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := hmacAuthsCollection()
 
 	var hmacAuth HMACAuth
 	hmacAuth.Username = kong.String("my-username")
@@ -47,7 +47,7 @@ func TestHMACAuthGet(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(hmacAuth)
+	err := collection.Add(hmacAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("first")
@@ -68,9 +68,7 @@ func TestHMACAuthGet(t *testing.T) {
 
 func TestHMACAuthUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewHMACAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := hmacAuthsCollection()
 
 	var hmacAuth HMACAuth
 	hmacAuth.Username = kong.String("my-username")
@@ -80,7 +78,7 @@ func TestHMACAuthUpdate(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(hmacAuth)
+	err := collection.Add(hmacAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("first")
@@ -104,9 +102,7 @@ func TestHMACAuthUpdate(t *testing.T) {
 
 func TestHMACAuthDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewHMACAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := hmacAuthsCollection()
 
 	var hmacAuth HMACAuth
 	hmacAuth.Username = kong.String("my-username1")
@@ -115,7 +111,7 @@ func TestHMACAuthDelete(t *testing.T) {
 		ID:       kong.String("consumer1-id"),
 		Username: kong.String("consumer1-name"),
 	}
-	err = collection.Add(hmacAuth)
+	err := collection.Add(hmacAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("my-username1")
@@ -139,9 +135,7 @@ func TestHMACAuthDelete(t *testing.T) {
 
 func TestHMACAuthGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewHMACAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := hmacAuthsCollection()
 
 	populateWithHMACAuthFixtures(assert, collection)
 
@@ -152,9 +146,7 @@ func TestHMACAuthGetAll(t *testing.T) {
 
 func TestHMACAuthGetByConsumer(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewHMACAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := hmacAuthsCollection()
 
 	populateWithHMACAuthFixtures(assert, collection)
 

--- a/state/jwtauth_test.go
+++ b/state/jwtauth_test.go
@@ -7,16 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func jwtAuthsCollection() *JWTAuthsCollection {
+	return state().JWTAuths
+}
+
 func TestJWTAuthInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewJWTAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := jwtAuthsCollection()
 
 	var jwtAuth JWTAuth
 	jwtAuth.Key = kong.String("my-key")
 	jwtAuth.ID = kong.String("first")
-	err = collection.Add(jwtAuth)
+	err := collection.Add(jwtAuth)
 	assert.NotNil(err)
 
 	var jwtAuth2 JWTAuth
@@ -32,9 +34,7 @@ func TestJWTAuthInsert(t *testing.T) {
 
 func TestJWTAuthGet(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewJWTAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := jwtAuthsCollection()
 
 	var jwtAuth JWTAuth
 	jwtAuth.Key = kong.String("my-key")
@@ -44,7 +44,7 @@ func TestJWTAuthGet(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(jwtAuth)
+	err := collection.Add(jwtAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("first")
@@ -65,9 +65,7 @@ func TestJWTAuthGet(t *testing.T) {
 
 func TestJWTAuthUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewJWTAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := jwtAuthsCollection()
 
 	var jwtAuth JWTAuth
 	jwtAuth.Key = kong.String("my-key")
@@ -77,7 +75,7 @@ func TestJWTAuthUpdate(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(jwtAuth)
+	err := collection.Add(jwtAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("first")
@@ -99,9 +97,7 @@ func TestJWTAuthUpdate(t *testing.T) {
 
 func TestJWTAuthDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewJWTAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := jwtAuthsCollection()
 
 	var jwtAuth JWTAuth
 	jwtAuth.Key = kong.String("my-key1")
@@ -110,7 +106,7 @@ func TestJWTAuthDelete(t *testing.T) {
 		ID:       kong.String("consumer1-id"),
 		Username: kong.String("consumer1-name"),
 	}
-	err = collection.Add(jwtAuth)
+	err := collection.Add(jwtAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("my-key1")
@@ -134,9 +130,7 @@ func TestJWTAuthDelete(t *testing.T) {
 
 func TestJWTAuthGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewJWTAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := jwtAuthsCollection()
 
 	populateWithJWTAuthFixtures(assert, collection)
 
@@ -147,9 +141,7 @@ func TestJWTAuthGetAll(t *testing.T) {
 
 func TestJWTAuthGetByConsumer(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewJWTAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := jwtAuthsCollection()
 
 	populateWithJWTAuthFixtures(assert, collection)
 

--- a/state/keyauth_test.go
+++ b/state/keyauth_test.go
@@ -7,16 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func keyAuthsCollection() *KeyAuthsCollection {
+	return state().KeyAuths
+}
+
 func TestKeyAuthInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewKeyAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := keyAuthsCollection()
 
 	var keyAuth KeyAuth
 	keyAuth.Key = kong.String("my-secret-apikey")
 	keyAuth.ID = kong.String("first")
-	err = collection.Add(keyAuth)
+	err := collection.Add(keyAuth)
 	assert.NotNil(err)
 
 	var keyAuth2 KeyAuth
@@ -32,9 +34,7 @@ func TestKeyAuthInsert(t *testing.T) {
 
 func TestKeyAuthGet(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewKeyAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := keyAuthsCollection()
 
 	var keyAuth KeyAuth
 	keyAuth.Key = kong.String("my-apikey")
@@ -44,7 +44,7 @@ func TestKeyAuthGet(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(keyAuth)
+	err := collection.Add(keyAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("first")
@@ -65,9 +65,7 @@ func TestKeyAuthGet(t *testing.T) {
 
 func TestKeyAuthUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewKeyAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := keyAuthsCollection()
 
 	var keyAuth KeyAuth
 	keyAuth.Key = kong.String("my-apikey")
@@ -77,7 +75,7 @@ func TestKeyAuthUpdate(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(keyAuth)
+	err := collection.Add(keyAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("first")
@@ -99,9 +97,7 @@ func TestKeyAuthUpdate(t *testing.T) {
 
 func TestKeyAuthDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewKeyAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := keyAuthsCollection()
 
 	var keyAuth KeyAuth
 	keyAuth.Key = kong.String("my-apikey1")
@@ -110,7 +106,7 @@ func TestKeyAuthDelete(t *testing.T) {
 		ID:       kong.String("consumer1-id"),
 		Username: kong.String("consumer1-name"),
 	}
-	err = collection.Add(keyAuth)
+	err := collection.Add(keyAuth)
 	assert.Nil(err)
 
 	res, err := collection.Get("my-apikey1")
@@ -134,9 +130,7 @@ func TestKeyAuthDelete(t *testing.T) {
 
 func TestKeyAuthGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewKeyAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := keyAuthsCollection()
 
 	populateWithKeyAuthFixtures(assert, collection)
 
@@ -147,9 +141,7 @@ func TestKeyAuthGetAll(t *testing.T) {
 
 func TestKeyAuthGetByConsumer(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewKeyAuthsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := keyAuthsCollection()
 
 	populateWithKeyAuthFixtures(assert, collection)
 

--- a/state/oauth2_test.go
+++ b/state/oauth2_test.go
@@ -7,16 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func oauth2CredsCollection() *Oauth2CredsCollection {
+	return state().Oauth2Creds
+}
+
 func TestOauth2CredInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewOauth2CredsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := oauth2CredsCollection()
 
 	var oauth2Cred Oauth2Credential
 	oauth2Cred.ClientID = kong.String("client-id")
 	oauth2Cred.ID = kong.String("first")
-	err = collection.Add(oauth2Cred)
+	err := collection.Add(oauth2Cred)
 	assert.NotNil(err)
 
 	oauth2Cred.Consumer = &kong.Consumer{
@@ -29,9 +31,7 @@ func TestOauth2CredInsert(t *testing.T) {
 
 func TestOauth2CredentialGet(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewOauth2CredsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := oauth2CredsCollection()
 
 	var oauth2Cred Oauth2Credential
 	oauth2Cred.ClientID = kong.String("my-clientid")
@@ -41,7 +41,7 @@ func TestOauth2CredentialGet(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(oauth2Cred)
+	err := collection.Add(oauth2Cred)
 	assert.Nil(err)
 
 	res, err := collection.Get("first")
@@ -62,9 +62,7 @@ func TestOauth2CredentialGet(t *testing.T) {
 
 func TestOauth2CredentialUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewOauth2CredsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := oauth2CredsCollection()
 
 	var oauth2Cred Oauth2Credential
 	oauth2Cred.ClientID = kong.String("my-clientid")
@@ -74,7 +72,7 @@ func TestOauth2CredentialUpdate(t *testing.T) {
 		Username: kong.String("consumer1-name"),
 	}
 
-	err = collection.Add(oauth2Cred)
+	err := collection.Add(oauth2Cred)
 	assert.Nil(err)
 
 	res, err := collection.Get("first")
@@ -96,9 +94,7 @@ func TestOauth2CredentialUpdate(t *testing.T) {
 
 func TestOauth2CredentialDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewOauth2CredsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := oauth2CredsCollection()
 
 	var oauth2Cred Oauth2Credential
 	oauth2Cred.ClientID = kong.String("my-clientid1")
@@ -107,7 +103,7 @@ func TestOauth2CredentialDelete(t *testing.T) {
 		ID:       kong.String("consumer1-id"),
 		Username: kong.String("consumer1-name"),
 	}
-	err = collection.Add(oauth2Cred)
+	err := collection.Add(oauth2Cred)
 	assert.Nil(err)
 
 	res, err := collection.Get("my-clientid1")
@@ -131,9 +127,7 @@ func TestOauth2CredentialDelete(t *testing.T) {
 
 func TestOauth2CredentialGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewOauth2CredsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := oauth2CredsCollection()
 
 	populateWithOauth2CredentialFixtures(assert, collection)
 
@@ -144,9 +138,7 @@ func TestOauth2CredentialGetAll(t *testing.T) {
 
 func TestOauth2CredentialGetByConsumer(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewOauth2CredsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := oauth2CredsCollection()
 
 	populateWithOauth2CredentialFixtures(assert, collection)
 

--- a/state/plugin_test.go
+++ b/state/plugin_test.go
@@ -7,23 +7,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func pluginsCollection() *PluginsCollection {
+	return state().Plugins
+}
+
 func TestPluginInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewPluginsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := pluginsCollection()
+
 	var plugin Plugin
 	plugin.Name = kong.String("my-plugin")
 	plugin.ID = kong.String("first")
-	err = collection.Add(plugin)
+	err := collection.Add(plugin)
 	assert.Nil(err)
 }
 
 func TestPluginGetUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewPluginsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := pluginsCollection()
+
 	var plugin Plugin
 	plugin.Name = kong.String("my-plugin")
 	plugin.ID = kong.String("first")
@@ -32,7 +34,7 @@ func TestPluginGetUpdate(t *testing.T) {
 		Name: kong.String("service1-name"),
 	}
 	assert.NotNil(plugin.Service)
-	err = collection.Add(plugin)
+	err := collection.Add(plugin)
 	assert.NotNil(plugin.Service)
 	assert.Nil(err)
 
@@ -106,9 +108,7 @@ func TestGetPluginByProp(t *testing.T) {
 		},
 	}
 	assert := assert.New(t)
-	collection, err := NewPluginsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := pluginsCollection()
 
 	for _, p := range plugins {
 		assert.Nil(collection.Add(p))
@@ -142,14 +142,12 @@ func TestGetPluginByProp(t *testing.T) {
 func TestPluginsInvalidType(t *testing.T) {
 	assert := assert.New(t)
 
-	collection, err := NewPluginsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := pluginsCollection()
 
 	var service Service
 	service.Name = kong.String("my-service")
 	service.ID = kong.String("first")
-	txn := collection.memdb.Txn(true)
+	txn := collection.db.Txn(true)
 	txn.Insert(pluginTableName, &service)
 	txn.Commit()
 
@@ -160,9 +158,7 @@ func TestPluginsInvalidType(t *testing.T) {
 
 func TestPluginDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewPluginsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := pluginsCollection()
 
 	var plugin Plugin
 	plugin.ID = kong.String("first")
@@ -175,7 +171,7 @@ func TestPluginDelete(t *testing.T) {
 		ID:   kong.String("service1-id"),
 		Name: kong.String("service1-name"),
 	}
-	err = collection.Add(plugin)
+	err := collection.Add(plugin)
 	assert.Nil(err)
 
 	p, err := collection.Get("first")
@@ -192,9 +188,7 @@ func TestPluginDelete(t *testing.T) {
 
 func TestPluginGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewPluginsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := pluginsCollection()
 
 	plugins := []*Plugin{
 		{

--- a/state/route_test.go
+++ b/state/route_test.go
@@ -7,16 +7,19 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func routesCollection() *RoutesCollection {
+	return state().Routes
+}
+
 func TestRouteInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewRoutesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := routesCollection()
+
 	var route Route
 	route.Name = kong.String("my-route")
 	route.ID = kong.String("first")
 	route.Hosts = kong.StringSlice("example.com", "demo.example.com")
-	err = collection.Add(route)
+	err := collection.Add(route)
 	assert.NotNil(err)
 
 	var route2 Route
@@ -35,9 +38,8 @@ func TestRouteInsert(t *testing.T) {
 
 func TestRouteGetUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewRoutesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := routesCollection()
+
 	var route Route
 	route.Name = kong.String("my-route")
 	route.ID = kong.String("first")
@@ -47,7 +49,7 @@ func TestRouteGetUpdate(t *testing.T) {
 		Name: kong.String("service1-name"),
 	}
 	assert.NotNil(route.Service)
-	err = collection.Add(route)
+	err := collection.Add(route)
 	assert.NotNil(route.Service)
 	assert.Nil(err)
 
@@ -68,14 +70,12 @@ func TestRouteGetUpdate(t *testing.T) {
 func TestRoutesInvalidType(t *testing.T) {
 	assert := assert.New(t)
 
-	collection, err := NewRoutesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := routesCollection()
 
 	var service Service
 	service.Name = kong.String("my-service")
 	service.ID = kong.String("first")
-	txn := collection.memdb.Txn(true)
+	txn := collection.db.Txn(true)
 	txn.Insert(routeTableName, &service)
 	txn.Commit()
 
@@ -92,9 +92,8 @@ func TestRoutesInvalidType(t *testing.T) {
 // is different from the one stored in MemDB.
 func TestRouteGetMemoryReference(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewRoutesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := routesCollection()
+
 	var route Route
 	route.Name = kong.String("my-route")
 	route.ID = kong.String("first")
@@ -104,7 +103,7 @@ func TestRouteGetMemoryReference(t *testing.T) {
 		Name: kong.String("service1-name"),
 	}
 	assert.NotNil(route.Service)
-	err = collection.Add(route)
+	err := collection.Add(route)
 	assert.NotNil(route.Service)
 	assert.Nil(err)
 
@@ -123,9 +122,7 @@ func TestRouteGetMemoryReference(t *testing.T) {
 
 func TestRouteDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewRoutesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := routesCollection()
 
 	var route Route
 	route.Name = kong.String("my-route")
@@ -135,7 +132,7 @@ func TestRouteDelete(t *testing.T) {
 		ID:   kong.String("service1-id"),
 		Name: kong.String("service1-name"),
 	}
-	err = collection.Add(route)
+	err := collection.Add(route)
 	assert.Nil(err)
 
 	re, err := collection.Get("my-route")
@@ -152,9 +149,7 @@ func TestRouteDelete(t *testing.T) {
 
 func TestRouteGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewRoutesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := routesCollection()
 
 	var route Route
 	route.Name = kong.String("my-route1")
@@ -164,7 +159,7 @@ func TestRouteGetAll(t *testing.T) {
 		ID:   kong.String("service1-id"),
 		Name: kong.String("service1-name"),
 	}
-	err = collection.Add(route)
+	err := collection.Add(route)
 	assert.Nil(err)
 
 	var route2 Route
@@ -186,9 +181,7 @@ func TestRouteGetAll(t *testing.T) {
 
 func TestRouteGetAllByServiceName(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewRoutesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := routesCollection()
 
 	targets := []*Route{
 		{
@@ -234,11 +227,11 @@ func TestRouteGetAllByServiceName(t *testing.T) {
 	}
 
 	for _, target := range targets {
-		err = collection.Add(*target)
+		err := collection.Add(*target)
 		assert.Nil(err)
 	}
 
-	targets, err = collection.GetAllByServiceID("upstream1-id")
+	targets, err := collection.GetAllByServiceID("upstream1-id")
 	assert.Nil(err)
 	assert.Equal(2, len(targets))
 

--- a/state/service_test.go
+++ b/state/service_test.go
@@ -7,15 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func servicesCollection() *ServicesCollection {
+	return state().Services
+}
+
 func TestServiceInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewServicesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := servicesCollection()
+
 	var service Service
 	service.ID = kong.String("first")
 	service.Host = kong.String("example.com")
-	err = collection.Add(service)
+	err := collection.Add(service)
 	assert.NotNil(err)
 
 	var service2 Service
@@ -30,14 +33,12 @@ func TestServiceInsert(t *testing.T) {
 
 func TestServiceGetUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewServicesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := servicesCollection()
 
 	var service Service
 	service.Name = kong.String("my-service")
 	service.ID = kong.String("first")
-	err = collection.Add(service)
+	err := collection.Add(service)
 	assert.Nil(err)
 
 	se, err := collection.Get("first")
@@ -58,14 +59,12 @@ func TestServiceGetUpdate(t *testing.T) {
 // is different from the one stored in MemDB.
 func TestServiceGetMemoryReference(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewServicesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := servicesCollection()
 
 	var service Service
 	service.Name = kong.String("my-service")
 	service.ID = kong.String("first")
-	err = collection.Add(service)
+	err := collection.Add(service)
 	assert.Nil(err)
 
 	se, err := collection.Get("first")
@@ -81,15 +80,12 @@ func TestServiceGetMemoryReference(t *testing.T) {
 
 func TestServicesInvalidType(t *testing.T) {
 	assert := assert.New(t)
-
-	collection, err := NewServicesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := servicesCollection()
 
 	var route Route
 	route.Name = kong.String("my-route")
 	route.ID = kong.String("first")
-	txn := collection.memdb.Txn(true)
+	txn := collection.db.Txn(true)
 	txn.Insert(serviceTableName, &route)
 	txn.Commit()
 
@@ -103,15 +99,13 @@ func TestServicesInvalidType(t *testing.T) {
 
 func TestServiceDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewServicesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := servicesCollection()
 
 	var service Service
 	service.Name = kong.String("my-service")
 	service.ID = kong.String("first")
 	service.Host = kong.String("example.com")
-	err = collection.Add(service)
+	err := collection.Add(service)
 	assert.Nil(err)
 
 	se, err := collection.Get("my-service")
@@ -128,9 +122,7 @@ func TestServiceDelete(t *testing.T) {
 
 func TestServiceGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewServicesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := servicesCollection()
 
 	services := []Service{
 		{
@@ -163,9 +155,7 @@ func TestServiceGetAll(t *testing.T) {
 // is different from the one stored in MemDB.
 func TestServiceGetAllMemoryReference(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewServicesCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := servicesCollection()
 
 	services := []Service{
 		{

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -12,3 +12,11 @@ func TestNewState(t *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(state)
 }
+
+func state() *KongState {
+	s, err := NewKongState()
+	if err != nil {
+		panic(err)
+	}
+	return s
+}

--- a/state/target_test.go
+++ b/state/target_test.go
@@ -7,16 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func targetsCollection() *TargetsCollection {
+	return state().Targets
+}
+
 func TestTargetInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewTargetsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := targetsCollection()
 
 	var t0 Target
 	t0.Target.Target = kong.String("my-target")
 	t0.ID = kong.String("first")
-	err = collection.Add(t0)
+	err := collection.Add(t0)
 	assert.NotNil(err)
 
 	var t1 Target
@@ -50,9 +52,8 @@ func TestTargetInsert(t *testing.T) {
 
 func TestTargetGetUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewTargetsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := targetsCollection()
+
 	var target Target
 	target.Target.Target = kong.String("my-target")
 	target.ID = kong.String("first")
@@ -61,7 +62,7 @@ func TestTargetGetUpdate(t *testing.T) {
 		Name: kong.String("upstream1-name"),
 	}
 	assert.NotNil(target.Upstream)
-	err = collection.Add(target)
+	err := collection.Add(target)
 	assert.NotNil(target.Upstream)
 	assert.Nil(err)
 
@@ -82,9 +83,8 @@ func TestTargetGetUpdate(t *testing.T) {
 // is different from the one stored in MemDB.
 func TestTargetGetMemoryReference(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewTargetsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := targetsCollection()
+
 	var target Target
 	target.Target.Target = kong.String("my-target")
 	target.ID = kong.String("first")
@@ -92,7 +92,7 @@ func TestTargetGetMemoryReference(t *testing.T) {
 		ID:   kong.String("upstream1-id"),
 		Name: kong.String("upstream1-name"),
 	}
-	err = collection.Add(target)
+	err := collection.Add(target)
 	assert.Nil(err)
 
 	re, err := collection.Get("upstream1-name", "first")
@@ -111,15 +111,13 @@ func TestTargetGetMemoryReference(t *testing.T) {
 func TestTargetsInvalidType(t *testing.T) {
 	assert := assert.New(t)
 
-	collection, err := NewTargetsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := targetsCollection()
 
 	var upstream Upstream
 	upstream.Name = kong.String("my-upstream")
 	upstream.ID = kong.String("first")
-	txn := collection.memdb.Txn(true)
-	err = txn.Insert(targetTableName, &upstream)
+	txn := collection.db.Txn(true)
+	err := txn.Insert(targetTableName, &upstream)
 	assert.NotNil(err)
 	txn.Abort()
 
@@ -139,7 +137,7 @@ func TestTargetsInvalidType(t *testing.T) {
 		},
 	}
 
-	txn = collection.memdb.Txn(true)
+	txn = collection.db.Txn(true)
 	err = txn.Insert(targetTableName, &target)
 	assert.Nil(err)
 	txn.Commit()
@@ -151,9 +149,7 @@ func TestTargetsInvalidType(t *testing.T) {
 
 func TestTargetDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewTargetsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := targetsCollection()
 
 	var target Target
 	target.Target.Target = kong.String("my-target")
@@ -162,7 +158,7 @@ func TestTargetDelete(t *testing.T) {
 		ID:   kong.String("upstream1-id"),
 		Name: kong.String("upstream1-name"),
 	}
-	err = collection.Add(target)
+	err := collection.Add(target)
 	assert.Nil(err)
 
 	re, err := collection.Get("upstream1-name", "my-target")
@@ -178,9 +174,7 @@ func TestTargetDelete(t *testing.T) {
 
 func TestTargetGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewTargetsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := targetsCollection()
 
 	var target Target
 	target.Target.Target = kong.String("my-target1")
@@ -189,7 +183,7 @@ func TestTargetGetAll(t *testing.T) {
 		ID:   kong.String("upstream1-id"),
 		Name: kong.String("upstream1-name"),
 	}
-	err = collection.Add(target)
+	err := collection.Add(target)
 	assert.Nil(err)
 
 	var target2 Target
@@ -210,9 +204,7 @@ func TestTargetGetAll(t *testing.T) {
 
 func TestTargetGetAllByUpstreamName(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewTargetsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := targetsCollection()
 
 	targets := []*Target{
 		{
@@ -258,11 +250,11 @@ func TestTargetGetAllByUpstreamName(t *testing.T) {
 	}
 
 	for _, target := range targets {
-		err = collection.Add(*target)
+		err := collection.Add(*target)
 		assert.Nil(err)
 	}
 
-	targets, err = collection.GetAllByUpstreamID("upstream1-id")
+	targets, err := collection.GetAllByUpstreamID("upstream1-id")
 	assert.Nil(err)
 	assert.Equal(2, len(targets))
 

--- a/state/upstream_test.go
+++ b/state/upstream_test.go
@@ -7,14 +7,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func upstreamsCollection() *UpstreamsCollection {
+	return state().Upstreams
+}
+
 func TestUpstreamInsert(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewUpstreamsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := upstreamsCollection()
+
 	var upstream Upstream
 	upstream.ID = kong.String("first")
-	err = collection.Add(upstream)
+	err := collection.Add(upstream)
 	assert.NotNil(err)
 
 	var upstream2 Upstream
@@ -28,14 +31,12 @@ func TestUpstreamInsert(t *testing.T) {
 
 func TestUpstreamGetUpdate(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewUpstreamsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := upstreamsCollection()
 
 	var upstream Upstream
 	upstream.Name = kong.String("my-upstream")
 	upstream.ID = kong.String("first")
-	err = collection.Add(upstream)
+	err := collection.Add(upstream)
 	assert.Nil(err)
 
 	se, err := collection.Get("first")
@@ -60,14 +61,12 @@ func TestUpstreamGetUpdate(t *testing.T) {
 // is different from the one stored in MemDB.
 func TestUpstreamGetMemoryReference(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewUpstreamsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := upstreamsCollection()
 
 	var upstream Upstream
 	upstream.Name = kong.String("my-upstream")
 	upstream.ID = kong.String("first")
-	err = collection.Add(upstream)
+	err := collection.Add(upstream)
 	assert.Nil(err)
 
 	se, err := collection.Get("first")
@@ -83,14 +82,12 @@ func TestUpstreamGetMemoryReference(t *testing.T) {
 func TestUpstreamsInvalidType(t *testing.T) {
 	assert := assert.New(t)
 
-	collection, err := NewUpstreamsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := upstreamsCollection()
 
 	var route Route
 	route.Name = kong.String("my-route")
 	route.ID = kong.String("first")
-	txn := collection.memdb.Txn(true)
+	txn := collection.db.Txn(true)
 	txn.Insert(upstreamTableName, &route)
 	txn.Commit()
 
@@ -101,14 +98,12 @@ func TestUpstreamsInvalidType(t *testing.T) {
 
 func TestUpstreamDelete(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewUpstreamsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := upstreamsCollection()
 
 	var upstream Upstream
 	upstream.Name = kong.String("my-upstream")
 	upstream.ID = kong.String("first")
-	err = collection.Add(upstream)
+	err := collection.Add(upstream)
 	assert.Nil(err)
 
 	se, err := collection.Get("my-upstream")
@@ -127,14 +122,12 @@ func TestUpstreamDelete(t *testing.T) {
 
 func TestUpstreamGetAll(t *testing.T) {
 	assert := assert.New(t)
-	collection, err := NewUpstreamsCollection()
-	assert.Nil(err)
-	assert.NotNil(collection)
+	collection := upstreamsCollection()
 
 	var upstream Upstream
 	upstream.Name = kong.String("my-upstream1")
 	upstream.ID = kong.String("first")
-	err = collection.Add(upstream)
+	err := collection.Add(upstream)
 	assert.Nil(err)
 
 	var upstream2 Upstream


### PR DESCRIPTION
This also reduces GC pressure happening due to multiple
memdbs.

In future, transactions across multiple tables can be performed as well.