### PR TITLE
feat(docker) optionally base of Kong image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG IMAGE_BASE=alpine:3.10
+
 FROM golang:1.13.0 AS build
 WORKDIR /deck
 COPY go.mod ./
@@ -6,8 +8,9 @@ RUN go mod download
 ADD . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o deck
 
-FROM alpine:3.10
+FROM ${IMAGE_BASE}
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY --from=build /deck/deck /usr/local/bin
-ENTRYPOINT ["deck"]
+COPY ./docker_entrypoint.sh /docker_entrypoint.sh
+ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set +e
+
+kong version &> /dev/null
+KONG_AVAILABLE=$?
+
+if [ "$KONG_AVAILABLE" -eq "0" ]
+then
+  kong start
+  if [ "$?" -ne "0" ]
+  then
+    return 1
+  fi
+fi
+
+
+deck "$@"
+STATUS=$?
+
+
+if [ "$KONG_AVAILABLE" -eq "0" ]
+then
+  kong stop
+fi
+
+exit $STATUS


### PR DESCRIPTION
When building the container, the argument `BASE_IMAGE` can be set
to an image name of a Kong image (must be Alpine). In that case
when executing, it will start Kong before executing decK, and stop
it afterwards.

This allows the container to be started with the same environment
variables as any other Kong container, and then decK can access
Kong locally (within the container).

example usecase is a Kong cluster in data-plane mode without an
admin api exposed.