### PR TITLE
fix(file) encode sni with name for compat with Kong's format

### DIFF
--- a/file/codegen/main.go
+++ b/file/codegen/main.go
@@ -63,10 +63,22 @@ func main() {
 	schema.Definitions["Consumer"].AnyOf = anyOfUsernameOrID
 	schema.Definitions["Upstream"].Required = []string{"name"}
 	schema.Definitions["FTarget"].Required = []string{"target"}
-
-	schema.Definitions["Certificate"].Required = []string{"cert", "key"}
 	schema.Definitions["FCACertificate"].Required = []string{"cert"}
 	schema.Definitions["FPlugin"].Required = []string{"name"}
+
+	schema.Definitions["FCertificate"].Required = []string{"cert", "key"}
+	schema.Definitions["FCertificate"].Properties["snis"] = &jsonschema.Type{
+		Type: "array",
+		Items: &jsonschema.Type{
+			Type: "object",
+			Properties: map[string]*jsonschema.Type{
+				"name": {
+					Type: "string",
+				},
+			},
+		},
+	}
+
 	// creds
 	schema.Definitions["ACLGroup"].Required = []string{"group"}
 	schema.Definitions["BasicAuth"].Required = []string{"username", "password"}

--- a/file/schema.go
+++ b/file/schema.go
@@ -168,10 +168,6 @@ const contentSchema = `{
       "type": "object"
     },
     "Certificate": {
-      "required": [
-        "cert",
-        "key"
-      ],
       "properties": {
         "cert": {
           "type": "string"
@@ -262,6 +258,10 @@ const contentSchema = `{
       "type": "object"
     },
     "FCertificate": {
+      "required": [
+        "cert",
+        "key"
+      ],
       "properties": {
         "cert": {
           "type": "string"
@@ -277,7 +277,12 @@ const contentSchema = `{
         },
         "snis": {
           "items": {
-            "type": "string"
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "type": "object"
           },
           "type": "array"
         },

--- a/file/types.go
+++ b/file/types.go
@@ -104,6 +104,102 @@ func (c FCertificate) id() string {
 	return ""
 }
 
+// Custom (Un)marshaling methods exist due to:
+// https://github.com/hbagdi/deck/issues/76
+
+type sni struct {
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+type cert struct {
+	ID        *string   `json:"id,omitempty" yaml:"id,omitempty"`
+	Cert      *string   `json:"cert,omitempty" yaml:"cert,omitempty"`
+	Key       *string   `json:"key,omitempty" yaml:"key,omitempty"`
+	CreatedAt *int64    `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	SNIs      []*sni    `json:"snis,omitempty" yaml:"snis,omitempty"`
+	Tags      []*string `json:"tags,omitempty" yaml:"tags,omitempty"`
+}
+
+func copyToCert(certificate FCertificate) cert {
+	c := cert{}
+	if certificate.ID != nil {
+		c.ID = certificate.ID
+	}
+	if certificate.Key != nil {
+		c.Key = certificate.Key
+	}
+	if certificate.Cert != nil {
+		c.Cert = certificate.Cert
+	}
+	if certificate.CreatedAt != nil {
+		c.CreatedAt = certificate.CreatedAt
+	}
+	if certificate.Tags != nil {
+		c.Tags = certificate.Tags
+	}
+	for _, sniName := range certificate.SNIs {
+		c.SNIs = append(c.SNIs, &sni{Name: kong.String(*sniName)})
+	}
+	return c
+}
+
+func copyFromCert(cert cert, certificate *FCertificate) {
+	if cert.ID != nil {
+		certificate.ID = cert.ID
+	}
+	if cert.Key != nil {
+		certificate.Key = cert.Key
+	}
+	if cert.Cert != nil {
+		certificate.Cert = cert.Cert
+	}
+	if cert.CreatedAt != nil {
+		certificate.CreatedAt = cert.CreatedAt
+	}
+	if cert.Tags != nil {
+		certificate.Tags = cert.Tags
+	}
+	for _, sni := range cert.SNIs {
+		certificate.SNIs = append(certificate.SNIs, kong.String(*sni.Name))
+	}
+}
+
+// MarshalYAML is a custom marshal to handle
+// SNI.
+func (c FCertificate) MarshalYAML() (interface{}, error) {
+	return copyToCert(c), nil
+}
+
+// UnmarshalYAML is a custom marshal method to handle
+// foreign references.
+func (c *FCertificate) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var cert cert
+	if err := unmarshal(&cert); err != nil {
+		return err
+	}
+	copyFromCert(cert, c)
+	return nil
+}
+
+// MarshalJSON is a custom marshal method to handle
+// foreign references.
+func (c FCertificate) MarshalJSON() ([]byte, error) {
+	cert := copyToCert(c)
+	return json.Marshal(cert)
+}
+
+// UnmarshalJSON is a custom marshal method to handle
+// foreign references.
+func (c *FCertificate) UnmarshalJSON(b []byte) error {
+	var cert cert
+	err := json.Unmarshal(b, &cert)
+	if err != nil {
+		return err
+	}
+	copyFromCert(cert, c)
+	return nil
+}
+
 // FCACertificate represents a Kong CACertificate.
 type FCACertificate struct {
 	kong.CACertificate `yaml:",inline,omitempty"`

--- a/file/types_test.go
+++ b/file/types_test.go
@@ -2,6 +2,7 @@ package file
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/hbagdi/go-kong/kong"
@@ -80,4 +81,94 @@ func TestPluginUnmarshalJSON(t *testing.T) {
 			ID: kong.String("bar"),
 		},
 	}, p.Plugin)
+}
+
+func Test_copyToCert(t *testing.T) {
+	type args struct {
+		certificate FCertificate
+	}
+	tests := []struct {
+		name string
+		args args
+		want cert
+	}{
+		{
+			name: "basic sanity",
+			args: args{
+				certificate: FCertificate{
+					Certificate: kong.Certificate{
+						Key:  kong.String("key"),
+						Cert: kong.String("cert"),
+						ID:   kong.String("cert-id"),
+						SNIs: kong.StringSlice("0.example.com", "1.example.com"),
+						Tags: kong.StringSlice("tag1", "tag2"),
+					},
+				},
+			},
+			want: cert{
+				Key:  kong.String("key"),
+				Cert: kong.String("cert"),
+				ID:   kong.String("cert-id"),
+				SNIs: []*sni{
+					{Name: kong.String("0.example.com")},
+					{Name: kong.String("1.example.com")},
+				},
+				Tags: kong.StringSlice("tag1", "tag2"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := copyToCert(tt.args.certificate); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("copyToCert() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_copyFromCert(t *testing.T) {
+	type args struct {
+		cert        cert
+		certificate *FCertificate
+	}
+	tests := []struct {
+		name string
+		args args
+		want *FCertificate
+	}{
+		{
+			name: "basic sanity",
+			args: args{
+				cert: cert{
+					Key:  kong.String("key"),
+					Cert: kong.String("cert"),
+					ID:   kong.String("cert-id"),
+					SNIs: []*sni{
+						{Name: kong.String("0.example.com")},
+						{Name: kong.String("1.example.com")},
+					},
+					Tags: kong.StringSlice("tag1", "tag2"),
+				},
+				certificate: &FCertificate{},
+			},
+			want: &FCertificate{
+				Certificate: kong.Certificate{
+					Key:  kong.String("key"),
+					Cert: kong.String("cert"),
+					ID:   kong.String("cert-id"),
+					SNIs: kong.StringSlice("0.example.com", "1.example.com"),
+					Tags: kong.StringSlice("tag1", "tag2"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			copyFromCert(tt.args.cert, tt.args.certificate)
+
+			if !reflect.DeepEqual(tt.args.certificate, tt.want) {
+				t.Errorf("copyFromCert() = %v, want %v", tt.args.certificate, tt.want)
+			}
+		})
+	}
 }

--- a/kong.yaml
+++ b/kong.yaml
@@ -88,9 +88,9 @@ certificates:
   tags:
   - cloudops-managed
   snis:
-  - demo1.example.com
-  - demo2.example.com
-  - demo3.example.com
+  - name: demo1.example.com
+  - name: demo2.example.com
+  - name: demo3.example.com
 plugins:
 - name: prometheus
   enabled: true


### PR DESCRIPTION
Kong's format requires SNIs to be `name: foo.example.com`.
This is a breaking change for decK.

decK aims to be compatible with Kong's configuration format.

Fix #76
Update #56