### PR TITLE
fix(file/builder): dont tag non-taggable consumer resources

### DIFF
--- a/file/builder.go
+++ b/file/builder.go
@@ -222,7 +222,6 @@ func (b *stateBuilder) ingestKeyAuths(creds []kong.KeyAuth) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.KeyAuths = append(b.rawState.KeyAuths, &cred)
 	}
 	return nil
@@ -241,7 +240,6 @@ func (b *stateBuilder) ingestBasicAuths(creds []kong.BasicAuth) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.BasicAuths = append(b.rawState.BasicAuths, &cred)
 	}
 	return nil
@@ -260,7 +258,6 @@ func (b *stateBuilder) ingestHMACAuths(creds []kong.HMACAuth) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.HMACAuths = append(b.rawState.HMACAuths, &cred)
 	}
 	return nil
@@ -279,7 +276,6 @@ func (b *stateBuilder) ingestJWTAuths(creds []kong.JWTAuth) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.JWTAuths = append(b.rawState.JWTAuths, &cred)
 	}
 	return nil
@@ -298,7 +294,6 @@ func (b *stateBuilder) ingestOauth2Creds(creds []kong.Oauth2Credential) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.Oauth2Creds = append(b.rawState.Oauth2Creds, &cred)
 	}
 	return nil
@@ -319,7 +314,6 @@ func (b *stateBuilder) ingestACLGroups(creds []kong.ACLGroup) error {
 				cred.ID = kong.String(*existingCred.ID)
 			}
 		}
-		utils.MustMergeTags(&cred, b.selectTags)
 		b.rawState.ACLGroups = append(b.rawState.ACLGroups, &cred)
 	}
 	return nil

--- a/file/builder_test.go
+++ b/file/builder_test.go
@@ -790,7 +790,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				BasicAuths: []*kong.BasicAuth{
@@ -801,7 +800,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				HMACAuths: []*kong.HMACAuth{
@@ -812,7 +810,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				JWTAuths: []*kong.JWTAuth{
@@ -823,7 +820,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				Oauth2Creds: []*kong.Oauth2Credential{
@@ -834,7 +830,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				ACLGroups: []*kong.ACLGroup{
@@ -844,7 +839,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("5b1484f2-5209-49d9-b43e-92ba09dd9d52"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 			},
@@ -938,7 +932,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				BasicAuths: []*kong.BasicAuth{
@@ -949,7 +942,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				HMACAuths: []*kong.HMACAuth{
@@ -960,7 +952,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				JWTAuths: []*kong.JWTAuth{
@@ -971,7 +962,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				Oauth2Creds: []*kong.Oauth2Credential{
@@ -982,7 +972,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 				ACLGroups: []*kong.ACLGroup{
@@ -992,7 +981,6 @@ func Test_stateBuilder_consumers(t *testing.T) {
 						Consumer: &kong.Consumer{
 							ID: kong.String("4bfcb11f-c962-4817-83e5-9433cf20b663"),
 						},
-						Tags: kong.StringSlice("tag1"),
 					},
 				},
 			},


### PR DESCRIPTION
Remove `MustMergeTags` from non-taggable consumer resources
Fix for: https://github.com/hbagdi/deck/issues/114

Resources: KeyAuths, BasicAuths, HMACAuths, JWTAuths, Oauth2Creds, ACLGroups

As this resources don't support tags, Merging Tags doesn't affect them (nil),  
except when using `select_tags`, that enforces the tags.
