### PR TITLE
fix: correctly parse Kong's version

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -140,5 +140,5 @@ func kongVersion(config utils.KongClientConfig) (semver.Version, error) {
 	}
 
 	v, err := utils.CleanKongVersion(root["version"].(string))
-	return semver.Make(v)
+	return semver.ParseTolerant(v)
 }


### PR DESCRIPTION
semver lib errors out if no patch is found.
Switch to ParseTolerant() which injects a `0` patch number.

Fix #117