### PR TITLE
feat(sync/diff) Add workspace arg to sync and diff commands

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hbagdi/deck/diff"
 	"github.com/hbagdi/deck/dump"
 	"github.com/hbagdi/deck/file"
+	"github.com/hbagdi/deck/print"
 	"github.com/hbagdi/deck/solver"
 	"github.com/hbagdi/deck/state"
 	"github.com/hbagdi/deck/utils"
@@ -81,7 +82,9 @@ func syncMain(filenames []string, dry bool, parallelism, delay int, workspace st
 		return err
 	}
 	// prepare to read the current state from Kong
-	if len(workspace) > 0 {
+	if workspace != "" {
+		print.DeletePrintf("Warning: Specified workspace '%v' is different from "+
+			"workspace '%v' found in state file(s)\n", workspace, targetContent.Workspace)
 		config.Workspace = workspace
 	} else {
 		config.Workspace = targetContent.Workspace

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -82,9 +82,9 @@ func syncMain(filenames []string, dry bool, parallelism, delay int, workspace st
 		return err
 	}
 	// prepare to read the current state from Kong
-	if workspace != "" {
-		print.DeletePrintf("Warning: Specified workspace '%v' is different from "+
-			"workspace '%v' found in state file(s)\n", workspace, targetContent.Workspace)
+	if workspace != targetContent.Workspace {
+		print.DeletePrintf("Warning: Workspace '%v' specified via --workspace flag is "+
+			"different from workspace '%v' found in state file(s).\n", workspace, targetContent.Workspace)
 		config.Workspace = workspace
 	} else {
 		config.Workspace = targetContent.Workspace

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -67,7 +67,7 @@ func checkWorkspace(config utils.KongClientConfig) error {
 	return nil
 }
 
-func syncMain(filenames []string, dry bool, parallelism, delay int) error {
+func syncMain(filenames []string, dry bool, parallelism, delay int, workspace string) error {
 
 	// load Kong version before workspace
 	kongVersion, err := kongVersion(config)
@@ -81,7 +81,11 @@ func syncMain(filenames []string, dry bool, parallelism, delay int) error {
 		return err
 	}
 	// prepare to read the current state from Kong
-	config.Workspace = targetContent.Workspace
+	if len(workspace) > 0 {
+		config.Workspace = workspace
+	} else {
+		config.Workspace = targetContent.Workspace
+	}
 
 	if err := checkWorkspace(config); err != nil {
 		return err

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -9,6 +9,7 @@ var (
 	diffCmdKongStateFile   []string
 	diffCmdParallelism     int
 	diffCmdNonZeroExitCode bool
+	diffWorkspace          string
 )
 
 // diffCmd represents the diff command
@@ -23,7 +24,7 @@ that will be created or updated or deleted.
 `,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return syncMain(diffCmdKongStateFile, true, diffCmdParallelism, 0)
+		return syncMain(diffCmdKongStateFile, true, diffCmdParallelism, 0, diffWorkspace)
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(diffCmdKongStateFile) == 0 {
@@ -40,6 +41,10 @@ func init() {
 		"state", "s", []string{"kong.yaml"}, "file(s) containing Kong's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.\n"+
 			"Use '-' to read from stdin.")
+	diffCmd.Flags().StringVarP(&diffWorkspace, "workspace", "w",
+		"", "Diff configuration with a specific workspace "+
+			"(Kong Enterprise only).\n"+
+			"This takes precedence over _workspace fields in state files.")
 	diffCmd.Flags().BoolVar(&dumpConfig.SkipConsumers, "skip-consumers",
 		false, "do not diff consumers or "+
 			"any plugins associated with consumers")

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -38,8 +38,8 @@ func init() {
 		"state", "s", []string{"kong.yaml"}, "file(s) containing Kong's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.\n"+
 			"Use '-' to read from stdin.")
-	syncCmd.Flags().StringVarP(&syncWorkspace, "workspace", "w",
-		"", "Sync configuration to a specific workspace "+
+	syncCmd.Flags().StringVar(&syncWorkspace, "workspace", "",
+		"Sync configuration to a specific workspace "+
 			"(Kong Enterprise only).\n"+
 			"This takes precedence over _workspace fields in state files.")
 	syncCmd.Flags().BoolVar(&dumpConfig.SkipConsumers, "skip-consumers",

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -9,6 +9,7 @@ var (
 	syncCmdKongStateFile []string
 	syncCmdParallelism   int
 	syncCmdDBUpdateDelay int
+	syncWorkspace        string
 )
 
 // syncCmd represents the sync command
@@ -20,7 +21,7 @@ var syncCmd = &cobra.Command{
 to get Kong's state in sync with the input state.`,
 	Args: validateNoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return syncMain(syncCmdKongStateFile, false, syncCmdParallelism, syncCmdDBUpdateDelay)
+		return syncMain(syncCmdKongStateFile, false, syncCmdParallelism, syncCmdDBUpdateDelay, syncWorkspace)
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(syncCmdKongStateFile) == 0 {
@@ -37,6 +38,10 @@ func init() {
 		"state", "s", []string{"kong.yaml"}, "file(s) containing Kong's configuration.\n"+
 			"This flag can be specified multiple times for multiple files.\n"+
 			"Use '-' to read from stdin.")
+	syncCmd.Flags().StringVarP(&syncWorkspace, "workspace", "w",
+		"", "Sync configuration to a specific workspace "+
+			"(Kong Enterprise only).\n"+
+			"This takes precedence over _workspace fields in state files.")
 	syncCmd.Flags().BoolVar(&dumpConfig.SkipConsumers, "skip-consumers",
 		false, "do not diff consumers or "+
 			"any plugins associated with consumers")


### PR DESCRIPTION
Allow specifying a workspace with `-w / --workspace` for the `sync` and `diff` commands - similar to how this is possible today for `dump` and `reset`.

### Use case(s)
1. Enables rolling out the same configuration across workspaces, e.g. the same logging plugin.
2. Easier sharing of deck configurations between Kong deployments (e.g. between different organizations, or different parts of the same organization), where the eventual workspace names cannot be known beforehand.