### PR TITLE
fix: Missing required fields cause panic

### DIFF
--- a/file/codegen/main.go
+++ b/file/codegen/main.go
@@ -26,19 +26,19 @@ var (
 	// routes and services
 	anyOfNameOrID = []*jsonschema.Type{
 		{
-			Required: []string{"id"},
+			Required: []string{"name"},
 		},
 		{
-			Required: []string{"name"},
+			Required: []string{"id"},
 		},
 	}
 
 	anyOfUsernameOrID = []*jsonschema.Type{
 		{
-			Required: []string{"id"},
+			Required: []string{"username"},
 		},
 		{
-			Required: []string{"username"},
+			Required: []string{"id"},
 		},
 	}
 )
@@ -59,10 +59,17 @@ func main() {
 	}
 	schema := reflector.Reflect(file.Content{})
 	schema.Definitions["Service"].AnyOf = anyOfNameOrID
+	schema.Definitions["FService"].AnyOf = anyOfNameOrID
 
 	schema.Definitions["Route"].AnyOf = anyOfNameOrID
+	schema.Definitions["FRoute"].AnyOf = anyOfNameOrID
+
 	schema.Definitions["Consumer"].AnyOf = anyOfUsernameOrID
+	schema.Definitions["FConsumer"].AnyOf = anyOfUsernameOrID
+
 	schema.Definitions["Upstream"].Required = []string{"name"}
+	schema.Definitions["FUpstream"].Required = []string{"name"}
+
 	schema.Definitions["FTarget"].Required = []string{"target"}
 	schema.Definitions["FCACertificate"].Required = []string{"cert"}
 	schema.Definitions["FPlugin"].Required = []string{"name"}

--- a/file/schema.go
+++ b/file/schema.go
@@ -232,12 +232,12 @@ const contentSchema = `{
       "anyOf": [
         {
           "required": [
-            "id"
+            "username"
           ]
         },
         {
           "required": [
-            "username"
+            "id"
           ]
         }
       ]
@@ -376,7 +376,19 @@ const contentSchema = `{
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "anyOf": [
+        {
+          "required": [
+            "username"
+          ]
+        },
+        {
+          "required": [
+            "id"
+          ]
+        }
+      ]
     },
     "FPlugin": {
       "required": [
@@ -532,7 +544,19 @@ const contentSchema = `{
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "anyOf": [
+        {
+          "required": [
+            "name"
+          ]
+        },
+        {
+          "required": [
+            "id"
+          ]
+        }
+      ]
     },
     "FService": {
       "properties": {
@@ -599,7 +623,19 @@ const contentSchema = `{
         }
       },
       "additionalProperties": false,
-      "type": "object"
+      "type": "object",
+      "anyOf": [
+        {
+          "required": [
+            "name"
+          ]
+        },
+        {
+          "required": [
+            "id"
+          ]
+        }
+      ]
     },
     "FTarget": {
       "required": [
@@ -633,6 +669,9 @@ const contentSchema = `{
       "type": "object"
     },
     "FUpstream": {
+      "required": [
+        "name"
+      ],
       "properties": {
         "algorithm": {
           "type": "string"
@@ -985,12 +1024,12 @@ const contentSchema = `{
       "anyOf": [
         {
           "required": [
-            "id"
+            "name"
           ]
         },
         {
           "required": [
-            "name"
+            "id"
           ]
         }
       ]
@@ -1072,12 +1111,12 @@ const contentSchema = `{
       "anyOf": [
         {
           "required": [
-            "id"
+            "name"
           ]
         },
         {
           "required": [
-            "name"
+            "id"
           ]
         }
       ]


### PR DESCRIPTION
The validation logic sometimes does not catch missing required fields, resulting in a panic. This updates the schema generation to fix it.

E.g. the following config:
```yaml
services:
- host: httpbin.org
  #name: service
  routes:
  - headers:
      my-header:
      - httpbin.org
    #name: route
    plugins:
    - name: key-auth
consumers:
- keyauth_credentials:
  - key: foo
  #username: consumer
upstreams:
- hash_on: none
  #name: upstream
```

will cause segfaults like the following for any of the commented out lines above:
```ShellSession
$ deck diff -s kong.yaml
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x141b947]

goroutine 7 [running]:
github.com/hbagdi/deck/file.(*stateBuilder).services(0xc0003cfb28)
	/home/hbagdi/deck/file/builder.go:392 +0x5d7
github.com/hbagdi/deck/file.(*stateBuilder).build(0xc0003cfb28, 0x0, 0x0, 0x0)
	/home/hbagdi/deck/file/builder.go:53 +0xfa
github.com/hbagdi/deck/file.Get(0xc000388000, 0xc00006d200, 0x1, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/hbagdi/deck/file/reader.go:51 +0x130
github.com/hbagdi/deck/cmd.syncMain(0xc00005c060, 0x1, 0x1, 0xc0000f9d01, 0xa, 0x0, 0x0)
	/home/hbagdi/deck/cmd/common.go:102 +0x325
github.com/hbagdi/deck/cmd.glob..func1(0x1ad8440, 0xc00000c0e0, 0x0, 0x2, 0x0, 0x0)
	/home/hbagdi/deck/cmd/diff.go:25 +0x56
github.com/spf13/cobra.(*Command).execute(0x1ad8440, 0xc00000c0a0, 0x2, 0x2, 0x1ad8440, 0xc00000c0a0)
	/home/hbagdi/go/pkg/mod/github.com/spf13/cobra@v0.0.7/command.go:838 +0x453
github.com/spf13/cobra.(*Command).ExecuteC(0x1ad79c0, 0x0, 0x0, 0x0)
	/home/hbagdi/go/pkg/mod/github.com/spf13/cobra@v0.0.7/command.go:943 +0x317
github.com/spf13/cobra.(*Command).Execute(...)
	/home/hbagdi/go/pkg/mod/github.com/spf13/cobra@v0.0.7/command.go:883
github.com/hbagdi/deck/cmd.Execute.func2(0xc00005c010, 0xc000028110)
	/home/hbagdi/deck/cmd/root.go:59 +0x2d
created by github.com/hbagdi/deck/cmd.Execute
	/home/hbagdi/deck/cmd/root.go:58 +0xba
```

Also switches the order in which one of two fields are required to have `id` last so it gives a more meaningful error message - only the first is displayed, e.g.:
```ShellSession
$ ./deck diff -s kong.yaml
Error: reading file: validating file content: 7 errors occurred:
	upstreams.0: name is required
	services.0: Must validate at least one schema (anyOf)
	services.0: name is required
	services.0.routes.0: Must validate at least one schema (anyOf)
	services.0.routes.0: name is required
	consumers.0: Must validate at least one schema (anyOf)
	consumers.0: username is required
```