### PR TITLE
fix(file) populate port according to protocol in url

### DIFF
--- a/file/types.go
+++ b/file/types.go
@@ -103,6 +103,12 @@ func unwrapURL(urlString string, fService *FService) error {
 	}
 
 	fService.Protocol = kong.String(parsed.Scheme)
+
+	fService.Port = kong.Int(80)
+	if parsed.Scheme == "https" {
+		fService.Port = kong.Int(443)
+	}
+
 	if parsed.Host != "" {
 		hostPort := strings.Split(parsed.Host, ":")
 		fService.Host = kong.String(hostPort[0])

--- a/file/types_test.go
+++ b/file/types_test.go
@@ -116,6 +116,21 @@ func Test_unwrapURL(t *testing.T) {
 						Host:     kong.String("foo.com"),
 						Protocol: kong.String("https"),
 						Path:     kong.String("/bar"),
+						Port:     kong.Int(443),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			args: args{
+				urlString: "https://foo.com:4224/",
+				fService: &FService{
+					Service: kong.Service{
+						Host:     kong.String("foo.com"),
+						Protocol: kong.String("https"),
+						Path:     kong.String("/"),
+						Port:     kong.Int(4224),
 					},
 				},
 			},
@@ -129,6 +144,33 @@ func Test_unwrapURL(t *testing.T) {
 						Host:     kong.String("foo.com"),
 						Protocol: kong.String("https"),
 						Path:     kong.String("/"),
+						Port:     kong.Int(443),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			args: args{
+				urlString: "http://foo.com:4242",
+				fService: &FService{
+					Service: kong.Service{
+						Host:     kong.String("foo.com"),
+						Protocol: kong.String("http"),
+						Port:     kong.Int(4242),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			args: args{
+				urlString: "http://foo.com",
+				fService: &FService{
+					Service: kong.Service{
+						Host:     kong.String("foo.com"),
+						Protocol: kong.String("http"),
+						Port:     kong.Int(80),
 					},
 				},
 			},
@@ -141,6 +183,7 @@ func Test_unwrapURL(t *testing.T) {
 					Service: kong.Service{
 						Host:     kong.String("foocom"),
 						Protocol: kong.String("grpc"),
+						Port:     kong.Int(80),
 					},
 				},
 			},


### PR DESCRIPTION
Populate port according to the protocol scheme in the `url` sugar
attribute. Default port of `80` is now populated to match Kong's
behavior in the same case.