### PR TITLE
fix(dump+reset): Check if workspace exists

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -112,6 +112,11 @@ configure Kong.`,
 		// or Kong Enterprise single workspace
 		if dumpWorkspace != "" {
 			config.Workspace = dumpWorkspace
+
+			if err := checkWorkspace(config); err != nil {
+				return err
+			}
+
 			client, err = utils.GetKongClient(config)
 			if err != nil {
 				return err

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -69,6 +69,12 @@ By default, this command will ask for a confirmation prompt.`,
 			}
 		}
 		if resetWorkspace != "" {
+			config.Workspace = resetWorkspace
+
+			if err := checkWorkspace(config); err != nil {
+				return err
+			}
+
 			workspaces = append(workspaces, resetWorkspace)
 		}
 


### PR DESCRIPTION
In `dump` and `reset` commands, checks if a specified workspace exists before trying to work with it. This makes sure the error message accurately reflects what the problem is.

E.g. right now:
```ShellSession
$ deck dump -w Demo
Error: reading configuration from Kong: snis: Not found
```

After this PR:
```ShellSession
$ deck dump -w Demo
Error: checking workspace 'Demo' in Kong: Not found
```

Uses the same code as is already in place for `sync` and `diff`.