### PR TITLE
fix(config) Ignore missing config file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,9 +144,10 @@ func initConfig() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	viper.AutomaticEnv() // read in environment variables that match
 	// If a config file is found, read it in.
-	err := viper.ReadInConfig()
-	if err != nil {
-		fmt.Println(err)
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			fmt.Println(err)
+		}
 	}
 	config.Address = viper.GetString("kong-addr")
 	config.TLSServerName = viper.GetString("tls-server-name")


### PR DESCRIPTION
Ignores a missing `.deck` file by adding code as recommended in https://github.com/spf13/viper/blob/master/README.md.

Fixes https://github.com/hbagdi/deck/issues/151.