### PR TITLE
Remove required jwt-auth fields from schema

### DIFF
--- a/file/codegen/main.go
+++ b/file/codegen/main.go
@@ -91,8 +91,7 @@ func main() {
 	schema.Definitions["ACLGroup"].Required = []string{"group"}
 	schema.Definitions["BasicAuth"].Required = []string{"username", "password"}
 	schema.Definitions["HMACAuth"].Required = []string{"username", "secret"}
-	schema.Definitions["JWTAuth"].Required = []string{"algorithm", "key",
-		"secret"}
+	schema.Definitions["JWTAuth"].Required = []string{}
 	schema.Definitions["KeyAuth"].Required = []string{"key"}
 	schema.Definitions["Oauth2Credential"].Required = []string{"name",
 		"client_id", "redirect_uris", "client_secret"}

--- a/file/schema.go
+++ b/file/schema.go
@@ -809,11 +809,6 @@ const contentSchema = `{
       "type": "object"
     },
     "JWTAuth": {
-      "required": [
-        "algorithm",
-        "key",
-        "secret"
-      ],
       "properties": {
         "algorithm": {
           "type": "string"


### PR DESCRIPTION
Per https://docs.konghq.com/hub/kong-inc/jwt/#create-a-jwt-credential
jwt-auth does not truly have required fields. It has pseudo-required
fields based on the value of other fields and/or will auto-populate
fields with random values.

Both of these concepts are too complex to express in decK's schema, so
removing all validation logic from it.

Fix #181