### PR TITLE
fix: Deduplicate tags before sending to Kong

### DIFF
--- a/dump/dump.go
+++ b/dump/dump.go
@@ -20,10 +20,24 @@ type Config struct {
 	SelectorTags []string
 }
 
+func deduplicate(stringSlice []string) []string {
+	existing := map[string]struct{}{}
+	result := []string{}
+
+	for _, s := range stringSlice {
+		if _, exists := existing[s]; !exists {
+			existing[s] = struct{}{}
+			result = append(result, s)
+		}
+	}
+
+	return result
+}
+
 func newOpt(tags []string) *kong.ListOpt {
 	opt := new(kong.ListOpt)
 	opt.Size = 1000
-	opt.Tags = kong.StringSlice(tags...)
+	opt.Tags = kong.StringSlice(deduplicate(tags)...)
 	opt.MatchAllTags = true
 	return opt
 }


### PR DESCRIPTION
When getting entities from Kong, decK will restrict the query to the tags in the state files. However, when using multiple state files, it will AND all tags it finds together - regardless of whether they are unique tags or just the same tags.

When the total number of tags is above 5, Kong will reject the query outright.

This PR deduplicates tags before they are sent to Kong. This allows having the same tag(s) in every file (to make sure it is never synced tag-less) - as long as the total unique number is not above 5.



