### PR TITLE
feat: always export ID for CACertificate

### DIFF
--- a/file/writer.go
+++ b/file/writer.go
@@ -267,7 +267,6 @@ func KongStateToFile(kongState *state.KongState, config WriteConfig) error {
 	}
 	for _, c := range caCertificates {
 		c := FCACertificate{CACertificate: c.CACertificate}
-		zeroOutID(&c, c.Cert, config.WithID)
 		zeroOutTimestamps(&c)
 		utils.MustRemoveTags(&c.CACertificate, selectTags)
 		file.CACertificates = append(file.CACertificates, c)


### PR DESCRIPTION
mtls-auth credentials can be tied to CACertificate.
This leads to a probelm where mtls-auth credential can contain an ID of
a CACertificate but CACertificate is exported to state file without an
ID. Now, on a subsequent `sync` from scratch, the ID of CACertificate
will be auto generated. This breaks the link between mtls-auth
credential and CACertificate, and the sync fails.

With this patch, like Certificate entity, ID of CACertificate is always
exported, no matter what.